### PR TITLE
[SREP-1201] Add support for multiple observatorium API URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,11 @@ example-config:
 		echo "graceful_timeout: 30s" >> example-config.yaml; \
 		echo "" >> example-config.yaml; \
 		echo "# API Configuration" >> example-config.yaml; \
-		echo "api_base_url: \"https://observatorium-api.example.com\"" >> example-config.yaml; \
+		echo "api_base_urls:" >> example-config.yaml; \
+		echo "  - \"https://observatorium-api-1.example.com\"" >> example-config.yaml; \
+		echo "  - \"https://observatorium-api-2.example.com\"" >> example-config.yaml; \
+		echo "  - \"https://observatorium-api-3.example.com\"" >> example-config.yaml; \
+		echo "" >> example-config.yaml; \
 		echo "api_tenant: \"default\"" >> example-config.yaml; \
 		echo "label_selector: \"private=false,rhobs-synthetics/status=pending\"" >> example-config.yaml; \
 		echo "" >> example-config.yaml; \

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -55,6 +55,10 @@ func main() {
 	startCmd.Flags().String("graceful-timeout", "30s", "Graceful shutdown timeout")
 	startCmd.Flags().String("kubeconfig", "", "Path to kubeconfig file (optional, for out-of-cluster development)")
 	startCmd.Flags().String("namespace", "default", "The Kubernetes namespace for probe resources")
+	
+	// API Config flags
+	startCmd.Flags().StringSlice("api-base-urls", []string{}, "Comma-separated list of base URLs for observatorium APIs")
+	startCmd.Flags().String("api-tenant", "default", "API tenant identifier")
 
 	// Bind flags to viper
 	_ = viper.BindPFlag("config", startCmd.Flags().Lookup("config"))
@@ -63,6 +67,8 @@ func main() {
 	_ = viper.BindPFlag("graceful_timeout", startCmd.Flags().Lookup("graceful-timeout"))
 	_ = viper.BindPFlag("kube_config", startCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("namespace", startCmd.Flags().Lookup("namespace"))
+	_ = viper.BindPFlag("api_base_urls", startCmd.Flags().Lookup("api-base-urls"))
+	_ = viper.BindPFlag("api_tenant", startCmd.Flags().Lookup("api-tenant"))
 
 	// Add commands to the root command
 	rootCmd.AddCommand(startCmd)

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -4,7 +4,11 @@ polling_interval: 10s
 graceful_timeout: 30s
 
 # API Configuration
-api_base_url: "https://observatorium-api.example.com"
+api_base_urls:
+  - "https://observatorium-api-1.example.com"
+  - "https://observatorium-api-2.example.com"
+  - "https://observatorium-api-3.example.com"
+
 api_tenant: "default"
 label_selector: "private=false,rhobs-synthetics/status=pending"
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -356,7 +356,7 @@ func TestAgent_Config_String_Integration(t *testing.T) {
 	agent := New(cfg)
 
 	// Verify the config string formatting works with the agent
-	expected := "LogLevel=debug, LogFormat=text, PollingInterval=45s, GracefulTimeout=1m0s"
+	expected := "LogLevel=debug, LogFormat=text, PollingInterval=45s, GracefulTimeout=1m0s, APIBaseURLs=[]"
 	actual := agent.config.String()
 
 	if actual != expected {

--- a/internal/agent/worker.go
+++ b/internal/agent/worker.go
@@ -14,18 +14,24 @@ import (
 
 type Worker struct {
 	config       *Config
-	apiClient    *api.Client
+	apiClients   []*api.Client
 	probeManager *k8s.ProbeManager
 }
 
 func NewWorker(cfg *Config) *Worker {
-	var apiClient *api.Client
+	var apiClients []*api.Client
 	var probeManager *k8s.ProbeManager
 
 	if cfg != nil {
-		if cfg.APIBaseURL != "" {
-			apiClient = api.NewClient(cfg.APIBaseURL, cfg.APITenant, cfg.APIEndpoint, cfg.JWTToken)
+		// Create API clients for each configured URL
+		apiURLs := cfg.GetAPIBaseURLs()
+		for _, baseURL := range apiURLs {
+			if baseURL != "" {
+				client := api.NewClient(baseURL, cfg.APITenant, cfg.APIEndpoint, cfg.JWTToken)
+				apiClients = append(apiClients, client)
+			}
 		}
+
 		namespace := cfg.Namespace
 		if namespace == "" {
 			namespace = "default"
@@ -37,13 +43,20 @@ func NewWorker(cfg *Config) *Worker {
 
 	return &Worker{
 		config:       cfg,
-		apiClient:    apiClient,
+		apiClients:   apiClients,
 		probeManager: probeManager,
 	}
 }
 
 func (w *Worker) Start(ctx context.Context, resourceMgr *ResourceManager, taskWG *sync.WaitGroup, shutdownChan chan struct{}) error {
 	log.Println("RHOBS Synthetic Agent worker thread started")
+
+	if len(w.apiClients) == 0 {
+		log.Println("Warning: No API URLs configured. Agent will run in standalone mode without probe processing.")
+		log.Println("To enable probe processing, configure api_base_urls in your config file or set API_BASE_URLS environment variable.")
+	} else {
+		log.Printf("Configured %d API endpoint(s) for probe processing", len(w.apiClients))
+	}
 
 	ticker := time.NewTicker(w.config.PollingInterval)
 	defer ticker.Stop()
@@ -93,8 +106,8 @@ func (w *Worker) processProbes(ctx context.Context, resourceMgr *ResourceManager
 	taskWG.Add(1)
 	defer taskWG.Done()
 
-	if w.apiClient == nil {
-		log.Println("API client not configured, skipping probe processing")
+	if len(w.apiClients) == 0 {
+		log.Println("No API URLs configured, continuing to run in standalone mode (no probe processing)")
 		return nil
 	}
 
@@ -123,25 +136,21 @@ func (w *Worker) processProbes(ctx context.Context, resourceMgr *ResourceManager
 		if err := w.processProbe(ctx, probe); err != nil {
 			log.Printf("Failed to process probe %s: %v", probe.ID, err)
 			// Update probe status to failed
-			if updateErr := w.apiClient.UpdateProbeStatus(probe.ID, "failed"); updateErr != nil {
-				log.Printf("Failed to update probe %s status to failed: %v", probe.ID, updateErr)
-			}
+			w.updateProbeStatus(probe.ID, "failed")
 		} else {
 			log.Printf("Successfully processed probe %s", probe.ID)
 			// Update probe status to active
-			if updateErr := w.apiClient.UpdateProbeStatus(probe.ID, "active"); updateErr != nil {
-				log.Printf("Failed to update probe %s status to active: %v", probe.ID, updateErr)
-			}
+			w.updateProbeStatus(probe.ID, "active")
 		}
 	}
 
 	return nil
 }
 
-// fetchProbeList retrieves probe configurations from the RHOBS Probes API
+// fetchProbeList retrieves probe configurations from all configured RHOBS Probes APIs
 func (w *Worker) fetchProbeList(ctx context.Context) ([]api.Probe, error) {
-	if w.apiClient == nil {
-		return nil, fmt.Errorf("API client not configured")
+	if len(w.apiClients) == 0 {
+		return []api.Probe{}, nil
 	}
 
 	labelSelector := ""
@@ -149,15 +158,73 @@ func (w *Worker) fetchProbeList(ctx context.Context) ([]api.Probe, error) {
 		labelSelector = w.config.LabelSelector
 	}
 
-	log.Printf("Fetching probe list from API with label selector: %s", labelSelector)
+	log.Printf("Fetching probe list from %d API endpoints with label selector: %s", len(w.apiClients), labelSelector)
 
-	probes, err := w.apiClient.GetProbes(labelSelector)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get probes from API: %w", err)
+	var allProbes []api.Probe
+	var errors []error
+
+	// Fetch probes from all API endpoints
+	for i, apiClient := range w.apiClients {
+		log.Printf("Fetching probes from API endpoint %d/%d", i+1, len(w.apiClients))
+
+		probes, err := apiClient.GetProbes(labelSelector)
+		if err != nil {
+			log.Printf("Failed to fetch probes from API endpoint %d: %v", i+1, err)
+			errors = append(errors, fmt.Errorf("API endpoint %d: %w", i+1, err))
+			continue
+		}
+
+		log.Printf("Successfully fetched %d probes from API endpoint %d", len(probes), i+1)
+		allProbes = append(allProbes, probes...)
 	}
 
-	log.Printf("Successfully fetched %d probes from API", len(probes))
-	return probes, nil
+	// If all API endpoints failed, return an error
+	if len(errors) == len(w.apiClients) {
+		return nil, fmt.Errorf("failed to fetch probes from all %d API endpoints: %v", len(w.apiClients), errors)
+	}
+
+	// Remove duplicate probes by ID
+	uniqueProbes := w.deduplicateProbes(allProbes)
+
+	log.Printf("Successfully fetched %d total probes (%d unique) from %d API endpoints", len(allProbes), len(uniqueProbes), len(w.apiClients))
+	return uniqueProbes, nil
+}
+
+// deduplicateProbes removes duplicate probes by URL, keeping the first occurrence
+func (w *Worker) deduplicateProbes(probes []api.Probe) []api.Probe {
+	seen := make(map[string]bool)
+	var unique []api.Probe
+
+	for _, probe := range probes {
+		if !seen[probe.StaticURL] {
+			seen[probe.StaticURL] = true
+			unique = append(unique, probe)
+		}
+	}
+
+	return unique
+}
+
+// updateProbeStatus updates the probe status on all API clients that might have this probe
+func (w *Worker) updateProbeStatus(probeID, status string) {
+	var errors []error
+	successCount := 0
+
+	for i, apiClient := range w.apiClients {
+		if err := apiClient.UpdateProbeStatus(probeID, status); err != nil {
+			log.Printf("Failed to update probe %s status on API endpoint %d: %v", probeID, i+1, err)
+			errors = append(errors, err)
+		} else {
+			log.Printf("Successfully updated probe %s status to %s on API endpoint %d", probeID, status, i+1)
+			successCount++
+		}
+	}
+
+	if successCount == 0 {
+		log.Printf("Failed to update probe %s status on all %d API endpoints", probeID, len(w.apiClients))
+	} else if len(errors) > 0 {
+		log.Printf("Updated probe %s status on %d/%d API endpoints", probeID, successCount, len(w.apiClients))
+	}
 }
 
 // processProbe creates a Custom Resource for a single probe

--- a/internal/agent/worker_integration_test.go
+++ b/internal/agent/worker_integration_test.go
@@ -20,7 +20,7 @@ func TestWorker_processProbe_Success(t *testing.T) {
 	defer validationServer.Close()
 
 	cfg := &Config{
-		APIBaseURL:    "http://example.com",
+		APIBaseURLs:    []string{"http://example.com"},
 		APITenant:     "test",
 		APIEndpoint:   "/api/metrics/v1",
 		LabelSelector: "test=true",
@@ -54,7 +54,7 @@ func TestWorker_processProbe_Success(t *testing.T) {
 
 func TestWorker_processProbe_ValidationFailure(t *testing.T) {
 	cfg := &Config{
-		APIBaseURL:    "http://example.com",
+		APIBaseURLs:    []string{"http://example.com"},
 		APITenant:     "test",
 		APIEndpoint:   "/api/metrics/v1",
 		LabelSelector: "test=true",
@@ -126,7 +126,7 @@ func TestWorker_FullIntegration(t *testing.T) {
 	cfg := &Config{
 		PollingInterval: 100 * time.Millisecond,
 		GracefulTimeout: 1 * time.Second,
-		APIBaseURL:      apiServer.URL,
+		APIBaseURLs:      []string{apiServer.URL},
 		APITenant:       "test",
 		APIEndpoint:     "/api/metrics/v1",
 		LabelSelector:   "test=true",
@@ -189,7 +189,7 @@ func TestWorker_processProbes_WithValidConfig(t *testing.T) {
 	defer apiServer.Close()
 
 	cfg := &Config{
-		APIBaseURL:    apiServer.URL,
+		APIBaseURLs:    []string{apiServer.URL},
 		APITenant:     "test",
 		APIEndpoint:   "/api/metrics/v1",
 		LabelSelector: "test=true",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -213,7 +213,7 @@ The e2e tests use the following agent configuration:
     LogFormat:       "text",
     PollingInterval: 2 * time.Second,
     GracefulTimeout: 5 * time.Second,
-    APIBaseURL:      mockAPI.URL,        // Points to mock server
+    APIBaseURLs:     []string{mockAPI.URL}, // Points to mock server
     APIEndpoint:     "/probes",
     LabelSelector:   "env=test,private=false",
 }

--- a/test/e2e/e2e_real_api_test.go
+++ b/test/e2e/e2e_real_api_test.go
@@ -34,7 +34,7 @@ func TestAgent_E2E_WithRealAPI(t *testing.T) {
 		LogFormat:       "text",
 		PollingInterval: 1 * time.Second,
 		GracefulTimeout: 2 * time.Second,
-		APIBaseURL:      apiManager.GetURL(),
+		APIBaseURLs:      []string{apiManager.GetURL()},
 		APIEndpoint:     "/probes",
 		LabelSelector:   "env=test,private=false",
 	}
@@ -189,7 +189,7 @@ func TestAgent_E2E_RealAPI_ErrorHandling(t *testing.T) {
 			LogFormat:       "text", 
 			PollingInterval: 1 * time.Second,
 			GracefulTimeout: 2 * time.Second,
-			APIBaseURL:      "http://localhost:9999", // Non-existent server
+			APIBaseURLs:      []string{"http://localhost:9999"}, // Non-existent server
 			APIEndpoint:     "/probes",
 			LabelSelector:   "env=test",
 		}
@@ -258,7 +258,7 @@ func TestAgent_E2E_RealAPI_ConfigurationVariations(t *testing.T) {
 				LogFormat:       "json",
 				PollingInterval: 1 * time.Second,
 				GracefulTimeout: 2 * time.Second,
-				APIBaseURL:      apiManager.GetURL(),
+				APIBaseURLs:      []string{apiManager.GetURL()},
 				APIEndpoint:     "/probes",
 				LabelSelector:   "", // No selector - should get all probes
 			},
@@ -271,7 +271,7 @@ func TestAgent_E2E_RealAPI_ConfigurationVariations(t *testing.T) {
 				LogFormat:       "json",
 				PollingInterval: 1 * time.Second,
 				GracefulTimeout: 2 * time.Second,
-				APIBaseURL:      apiManager.GetURL(),
+				APIBaseURLs:      []string{apiManager.GetURL()},
 				APIEndpoint:     "/probes",
 				LabelSelector:   "env=test,private=false,nonexistent=value",
 			},
@@ -295,7 +295,7 @@ func TestAgent_E2E_RealAPI_ConfigurationVariations(t *testing.T) {
 			time.Sleep(2 * time.Second)
 
 			// Test API client with same configuration
-			client := api.NewClient(tc.config.APIBaseURL, "", tc.config.APIEndpoint, "")
+			client := api.NewClient(tc.config.APIBaseURLs[0], "", tc.config.APIEndpoint, "")
 			probes, err := client.GetProbes(tc.config.LabelSelector)
 			
 			if err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,7 +21,7 @@ func TestAgent_E2E_WithAPI(t *testing.T) {
 		LogFormat:       "text",
 		PollingInterval: 1 * time.Second,
 		GracefulTimeout: 2 * time.Second,
-		APIBaseURL:      mockAPI.URL,
+		APIBaseURLs:     []string{mockAPI.URL},
 		APIEndpoint:     "/probes",
 		LabelSelector:   "env=test,private=false",
 	}
@@ -167,7 +167,7 @@ func TestAgent_E2E_ErrorHandling(t *testing.T) {
 			LogFormat:       "text", 
 			PollingInterval: 1 * time.Second,
 			GracefulTimeout: 2 * time.Second,
-			APIBaseURL:      "http://localhost:9999", // Non-existent server
+			APIBaseURLs:      []string{"http://localhost:9999"}, // Non-existent server
 			APIEndpoint:     "/probes",
 			LabelSelector:   "env=test",
 		}
@@ -222,7 +222,7 @@ func TestAgent_E2E_ConfigurationVariations(t *testing.T) {
 				LogFormat:       "json",
 				PollingInterval: 1 * time.Second,
 				GracefulTimeout: 2 * time.Second,
-				APIBaseURL:      mockAPI.URL,
+				APIBaseURLs:     []string{mockAPI.URL},
 				APIEndpoint:     "/probes",
 				LabelSelector:   "", // No selector - should get all probes
 			},
@@ -235,7 +235,7 @@ func TestAgent_E2E_ConfigurationVariations(t *testing.T) {
 				LogFormat:       "json",
 				PollingInterval: 1 * time.Second,
 				GracefulTimeout: 2 * time.Second,
-				APIBaseURL:      mockAPI.URL,
+				APIBaseURLs:     []string{mockAPI.URL},
 				APIEndpoint:     "/probes",
 				LabelSelector:   "env=test,private=false,nonexistent=value",
 			},
@@ -259,7 +259,7 @@ func TestAgent_E2E_ConfigurationVariations(t *testing.T) {
 			time.Sleep(2 * time.Second)
 
 			// Test API client with same configuration
-			client := api.NewClient(tc.config.APIBaseURL, "", tc.config.APIEndpoint, "")
+			client := api.NewClient(tc.config.APIBaseURLs[0], "", tc.config.APIEndpoint, "")
 			probes, err := client.GetProbes(tc.config.LabelSelector)
 			
 			if err != nil {

--- a/test/e2e/k8s_probe_e2e_test.go
+++ b/test/e2e/k8s_probe_e2e_test.go
@@ -51,7 +51,7 @@ func TestAgent_E2E_KubernetesProbeCreation(t *testing.T) {
 		LogFormat:       "text",
 		PollingInterval: 1 * time.Second,
 		GracefulTimeout: 2 * time.Second,
-		APIBaseURL:      mockAPI.URL,
+		APIBaseURLs:     []string{mockAPI.URL},
 		APIEndpoint:     "/probes",
 		LabelSelector:   "env=test,private=false",
 	}


### PR DESCRIPTION
Add support for multiple observatorium API URLs:
- Replace single api_base_url with api_base_urls array configuration
- Add support for multiple API endpoints via CLI, environment variables, and YAML
- Implement probe deduplication across multiple API sources
- Add status update distribution to all relevant API endpoints
- Enhance error handling to continue when some APIs are unavailable
- Add comprehensive test coverage for new multi-URL functionality
- Update documentation and examples for multiple API URL usage

Agent now polls multiple observatorium APIs simultaneously, deduplicates probes by URL, and updates probe status across all configured endpoints. Configuration supports comma-separated URLs in environment variables and array format in YAML files.