### PR TITLE
[SREP-800] Add OpenShift templates for Deployable synthetics-agent

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,186 @@
+# RHOBS Synthetics Agent OpenShift Template
+
+This OpenShift template deploys the RHOBS Synthetics Agent on an OpenShift cluster.
+
+## Prerequisites
+
+- OpenShift cluster
+- Cluster administrator access (for ClusterRole/ClusterRoleBinding)
+- Probe Custom Resource Definitions installed (`monitoring.rhobs/v1` or `monitoring.coreos.com/v1`)
+
+## Installation
+
+### Quick Installation
+```bash
+# Process and create from template with default parameters
+oc process -f deploy/template.yaml | oc apply -f -
+
+# Install in specific namespace
+oc process -f deploy/template.yaml -p NAMESPACE=openshift-monitoring | oc apply -f -
+
+# Install with parameter file
+oc process -f deploy/template.yaml --param-file=deploy/example-parameters.env | oc apply -f -
+```
+
+### Custom Installation
+```bash
+# Process template with custom parameters
+oc process -f deploy/template.yaml \
+  -p APPLICATION_NAME=my-synthetics-agent \
+  -p API_TENANT=my-tenant \
+  -p LOG_LEVEL=debug \
+  | oc apply -f -
+```
+
+## Configuration
+
+### Template Parameters
+
+The following table lists the most important configurable parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `API_BASE_URLS` | YAML list of API URLs to poll for probes | Single example URL |
+| `API_TENANT` | API tenant identifier | `"default"` |
+| `LABEL_SELECTOR` | Label selector for filtering probes | `"private=false,rhobs-synthetics/status=pending"` |
+| `PROBE_NAMESPACE` | namespace for probe resources | `"openshift-monitoring"` |
+| `POLLING_INTERVAL` | How often to poll APIs | `"30s"` |
+| `LOG_LEVEL` | Log level (debug, info, warn, error) | `"info"` |
+| `REPLICA_COUNT` | Number of replicas | `"1"` |
+| `CPU_LIMIT` / `MEMORY_LIMIT` | Resource limits | `500m` / `512Mi` |
+
+### Parameter Files
+
+Use the provided parameter files for different environments:
+
+#### Development Configuration
+```bash
+# Copy and customize the development parameters
+cp deploy/example-parameters.env deploy/my-dev-params.env
+# Edit deploy/my-dev-params.env with your values
+oc process -f deploy/template.yaml --param-file=deploy/my-dev-params.env | oc apply -f -
+```
+
+#### Custom API Configuration
+```bash
+# For multiple API URLs, use YAML format in the parameter file:
+API_BASE_URLS=|2+
+
+  - "https://api1.example.com"
+  - "https://api2.example.com"
+  - "https://api3.example.com"
+```
+
+## Required Permissions
+
+The agent requires the following permissions:
+
+- **Probe CRDs**: `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
+- **CRDs**: `get`, `list` (to detect available API groups)
+- **Namespaces**: `get`, `list`
+
+These are automatically configured through the included RBAC resources in the template.
+
+## Monitoring and Observability
+
+### Health Checks
+
+The agent exposes health endpoints on port 8080 (when implemented):
+- `/health` - Liveness probe endpoint
+- `/ready` - Readiness probe endpoint
+
+### Logs
+
+Configure logging via parameters:
+```bash
+oc process -f deploy/template.yaml \
+  -p LOG_LEVEL=debug \
+  -p LOG_FORMAT=json \
+  | oc apply -f -
+```
+
+View logs:
+```bash
+# View current logs
+oc logs deployment/rhobs-synthetics-agent
+
+# Follow logs
+oc logs -f deployment/rhobs-synthetics-agent
+
+# View logs from specific pod
+oc logs -l app.kubernetes.io/name=rhobs-synthetics-agent
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Probe CRDs not found**
+   ```bash
+   oc get crd probes.monitoring.rhobs probes.monitoring.coreos.com
+   ```
+
+2. **Permission denied creating probes**
+   ```bash
+   oc auth can-i create probes.monitoring.rhobs --as=system:serviceaccount:monitoring:rhobs-synthetics-agent
+   ```
+
+3. **API connection issues**
+   Check the agent logs and verify API URLs and authentication.
+
+### Debug Mode
+
+Enable debug logging:
+```bash
+oc process -f deploy/template.yaml -p LOG_LEVEL=debug | oc apply -f -
+```
+
+### Checking Agent Status
+
+```bash
+# Check pod logs
+oc logs -l app.kubernetes.io/name=rhobs-synthetics-agent
+
+# Check created probes
+oc get probes -A
+
+# Describe the deployment
+oc describe deployment rhobs-synthetics-agent
+
+# Check template processing
+oc process -f deploy/template.yaml --param-file=deploy/parameters.env
+```
+
+## Uninstalling
+
+```bash
+# Delete all resources created by the template
+oc process -f deploy/template.yaml | oc delete -f -
+
+# Or delete by labels
+oc delete all,configmap,serviceaccount,clusterrole,clusterrolebinding -l template=rhobs-synthetics-agent
+```
+
+Note: This will not remove the Probe Custom Resources that were created by the agent.
+
+## Development
+
+### Testing Template
+
+```bash
+# Process template without applying
+oc process -f deploy/template.yaml --param-file=deploy/parameters.env
+
+# Validate template syntax
+oc process -f deploy/template.yaml --param-file=deploy/parameters.env --dry-run=client
+
+# Test with different parameters
+oc process -f deploy/template.yaml -p REPLICA_COUNT=2 -p LOG_LEVEL=debug
+```
+
+### Adding to OpenShift Catalog
+
+```bash
+# Create template in openshift namespace to make it available cluster-wide
+oc create -f deploy/template.yaml -n openshift
+```

--- a/deploy/example-parameters.env
+++ b/deploy/example-parameters.env
@@ -1,0 +1,42 @@
+# RHOBS Synthetics Agent OpenShift Template Parameters
+# Copy this file and customize the values for your environment
+
+# Application Configuration
+APPLICATION_NAME=rhobs-synthetics-agent
+NAMESPACE=openshift-monitoring
+REPLICA_COUNT=1
+
+# Container Image Configuration
+IMAGE_REGISTRY=quay.io
+IMAGE_NAMESPACE=rhobs
+IMAGE_NAME=rhobs-synthetics-agent
+IMAGE_TAG=latest
+IMAGE_PULL_POLICY=Always
+
+# Resource Configuration
+CPU_REQUEST=100m
+CPU_LIMIT=500m
+MEMORY_REQUEST=128Mi
+MEMORY_LIMIT=512Mi
+
+# Application Settings
+LOG_LEVEL=info
+LOG_FORMAT=json
+POLLING_INTERVAL=30s
+GRACEFUL_TIMEOUT=30s
+
+# API Configuration
+# Note: For multiple URLs, use YAML format with proper indentation
+API_BASE_URLS=|2+
+  - "https://observatorium-api-1.example.com"
+  - "https://observatorium-api-2.example.com"
+API_TENANT=default
+LABEL_SELECTOR=private=false,rhobs-synthetics/status=pending
+
+# Kubernetes Configuration
+PROBE_NAMESPACE=openshift-monitoring
+
+# Blackbox Exporter Configuration
+BLACKBOX_INTERVAL=30s
+BLACKBOX_MODULE=http_2xx
+BLACKBOX_PROBER_URL=http://blackbox-exporter:9115

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1,0 +1,291 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhobs-synthetics-agent
+  annotations:
+    description: "RHOBS Synthetics Agent - synthetic monitoring agent for Red Hat Observability Service"
+    tags: "monitoring,synthetics,rhobs,observability"
+    iconClass: "icon-other-unknown"
+    openshift.io/display-name: "RHOBS Synthetics Agent"
+    openshift.io/documentation-url: "https://github.com/redhat-observability/rhobs-synthetics-agent"
+    openshift.io/support-url: "https://github.com/redhat-observability/rhobs-synthetics-agent/issues"
+    openshift.io/provider-display-name: "Red Hat"
+labels:
+  app: rhobs-synthetics-agent
+  template: rhobs-synthetics-agent
+objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ${APPLICATION_NAME}
+    labels:
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/component: synthetics-agent
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/managed-by: openshift-template
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: ${APPLICATION_NAME}
+    labels:
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/component: synthetics-agent
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/managed-by: openshift-template
+  rules:
+    # Access to Probe CRDs (monitoring.rhobs/v1)
+    - apiGroups: ["monitoring.rhobs"]
+      resources: ["probes"]
+      verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    # Access to Probe CRDs (monitoring.coreos.com/v1) - alternative API group
+    - apiGroups: ["monitoring.coreos.com"]
+      resources: ["probes"]
+      verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    # Access to read existing CRDs to detect which API group is available
+    - apiGroups: ["apiextensions.k8s.io"]
+      resources: ["customresourcedefinitions"]
+      verbs: ["get", "list"]
+    # Access to read namespaces
+    - apiGroups: [""]
+      resources: ["namespaces"]
+      verbs: ["get", "list"]
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ${APPLICATION_NAME}
+    labels:
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/component: synthetics-agent
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/managed-by: openshift-template
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: ${APPLICATION_NAME}
+  subjects:
+    - kind: ServiceAccount
+      name: ${APPLICATION_NAME}
+      namespace: ${NAMESPACE}
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: ${APPLICATION_NAME}-config
+    labels:
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/component: synthetics-agent
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/managed-by: openshift-template
+  data:
+    config.yaml: |
+      # Logging configuration
+      log_level: ${LOG_LEVEL}
+      log_format: ${LOG_FORMAT}
+
+      # Polling configuration
+      polling_interval: ${POLLING_INTERVAL}
+      graceful_timeout: ${GRACEFUL_TIMEOUT}
+
+      # API Configuration
+      api_base_urls:${API_BASE_URLS}
+      api_tenant: ${API_TENANT}
+      label_selector: ${LABEL_SELECTOR}
+
+      # Kubernetes Configuration
+      namespace: ${PROBE_NAMESPACE}
+
+      # Blackbox Configuration
+      blackbox:
+        interval: ${BLACKBOX_INTERVAL}
+        module: ${BLACKBOX_MODULE}
+        prober_url: ${BLACKBOX_PROBER_URL}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: ${APPLICATION_NAME}
+    labels:
+      app.kubernetes.io/name: ${APPLICATION_NAME}
+      app.kubernetes.io/component: synthetics-agent
+      app.kubernetes.io/part-of: rhobs
+      app.kubernetes.io/managed-by: openshift-template
+  spec:
+    replicas: ${{REPLICA_COUNT}}
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: ${APPLICATION_NAME}
+        deployment: ${APPLICATION_NAME}
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/name: ${APPLICATION_NAME}
+          app.kubernetes.io/component: synthetics-agent
+          app.kubernetes.io/part-of: rhobs
+          deployment: ${APPLICATION_NAME}
+      spec:
+        serviceAccountName: ${APPLICATION_NAME}
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+          runAsGroup: 1001
+          fsGroup: 1001
+        containers:
+          - name: synthetics-agent
+            image: ${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}
+            imagePullPolicy: ${IMAGE_PULL_POLICY}
+            command:
+              - ./rhobs-synthetics-agent
+            args:
+              - start
+              - --config
+              - /etc/config/config.yaml
+            ports:
+              - name: http
+                containerPort: 8080
+                protocol: TCP
+            env:
+              - name: NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            resources:
+              limits:
+                cpu: ${CPU_LIMIT}
+                memory: ${MEMORY_LIMIT}
+              requests:
+                cpu: ${CPU_REQUEST}
+                memory: ${MEMORY_REQUEST}
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: false
+            volumeMounts:
+              - name: config
+                mountPath: /etc/config
+                readOnly: true
+        volumes:
+          - name: config
+            configMap:
+              name: ${APPLICATION_NAME}-config
+parameters:
+- name: APPLICATION_NAME
+  displayName: Application Name
+  description: The name assigned to all objects and the related imagestream.
+  value: rhobs-synthetics-agent
+  required: true
+- name: NAMESPACE
+  displayName: Namespace
+  description: The OpenShift Namespace where the ImageStream resides.
+  value: openshift-monitoring
+  required: true
+- name: IMAGE_REGISTRY
+  displayName: Image Registry
+  description: Container image registry
+  value: quay.io
+  required: true
+- name: IMAGE_NAMESPACE
+  displayName: Image Namespace
+  description: Namespace/organization in the image registry
+  value: rhobs
+  required: true
+- name: IMAGE_NAME
+  displayName: Image Name
+  description: Container image name
+  value: rhobs-synthetics-agent
+  required: true
+- name: IMAGE_TAG
+  displayName: Image Tag
+  description: Container image tag
+  value: latest
+  required: true
+- name: IMAGE_PULL_POLICY
+  displayName: Image Pull Policy
+  description: Image pull policy for the container image
+  value: Always
+  required: true
+- name: REPLICA_COUNT
+  displayName: Replica Count
+  description: Number of replicas to deploy
+  value: "1"
+  required: true
+- name: CPU_REQUEST
+  displayName: CPU Request
+  description: Minimum amount of CPU the container needs
+  value: 100m
+  required: true
+- name: CPU_LIMIT
+  displayName: CPU Limit
+  description: Maximum amount of CPU the container can use
+  value: 500m
+  required: true
+- name: MEMORY_REQUEST
+  displayName: Memory Request
+  description: Minimum amount of memory the container needs
+  value: 128Mi
+  required: true
+- name: MEMORY_LIMIT
+  displayName: Memory Limit
+  description: Maximum amount of memory the container can use
+  value: 512Mi
+  required: true
+- name: LOG_LEVEL
+  displayName: Log Level
+  description: Application log level (debug, info, warn, error)
+  value: info
+  required: true
+- name: LOG_FORMAT
+  displayName: Log Format
+  description: Application log format (json, text)
+  value: json
+  required: true
+- name: POLLING_INTERVAL
+  displayName: Polling Interval
+  description: How often to poll APIs for probe configurations
+  value: 30s
+  required: true
+- name: GRACEFUL_TIMEOUT
+  displayName: Graceful Timeout
+  description: Graceful shutdown timeout
+  value: 30s
+  required: true
+- name: API_BASE_URLS
+  displayName: API Base URLs
+  description: YAML list of API URLs to poll (including leading newlines and spaces)
+  value: |2+
+        - "https://observatorium-api.example.com"
+  required: true
+- name: API_TENANT
+  displayName: API Tenant
+  description: API tenant identifier
+  value: default
+  required: true
+- name: LABEL_SELECTOR
+  displayName: Label Selector
+  description: Label selector for filtering probes
+  value: private=false,rhobs-synthetics/status=pending
+  required: true
+- name: PROBE_NAMESPACE
+  displayName: Probe Namespace
+  description: Kubernetes namespace where probe resources will be created
+  value: openshift-monitoring
+  required: true
+- name: BLACKBOX_INTERVAL
+  displayName: Blackbox Interval
+  description: Blackbox probe interval
+  value: 30s
+  required: true
+- name: BLACKBOX_MODULE
+  displayName: Blackbox Module
+  description: Blackbox exporter module to use
+  value: http_2xx
+  required: true
+- name: BLACKBOX_PROBER_URL
+  displayName: Blackbox Prober URL
+  description: URL of the blackbox exporter prober
+  value: http://blackbox-exporter:9115
+  required: true


### PR DESCRIPTION
Add OpenShift templates for deployable synthetics-agent:
- Create OpenShift template with all resources (ServiceAccount, RBAC, ConfigMap, Deployment)
- Add configurable parameters for easy environment customization (24 parameters)
- Include parameter files for example configurations
- Support for multiple API URLs via YAML configuration
- Proper RBAC permissions for both monitoring.rhobs/v1 and monitoring.coreos.com/v1 Probe CRDs
- Security hardening with non-root user and dropped capabilities
- Documentation for OpenShift deployment and troubleshooting

[SREP-800](https://issues.redhat.com/browse/SREP-800)