### PR TITLE
SREP-799: Add HTTP health endpoints for liveness and readiness checks

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -439,5 +440,213 @@ func BenchmarkConfig_String(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		_ = cfg.String()
+	}
+}
+
+func TestAgent_handleLiveness(t *testing.T) {
+	agent := New(nil)
+	
+	req := httptest.NewRequest("GET", "/livez", nil)
+	w := httptest.NewRecorder()
+	
+	agent.handleLiveness(w, req)
+	
+	resp := w.Result()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("Failed to close response body: %v", err)
+		}
+	}()
+	
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+	
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+	
+	expected := "OK"
+	if string(body) != expected {
+		t.Errorf("Expected body %q, got %q", expected, string(body))
+	}
+	
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != "text/plain" {
+		t.Errorf("Expected Content-Type 'text/plain', got %q", contentType)
+	}
+}
+
+func TestAgent_handleReadiness_NotReady(t *testing.T) {
+	agent := New(nil)
+	// Agent starts as not ready
+	
+	req := httptest.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	
+	agent.handleReadiness(w, req)
+	
+	resp := w.Result()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("Failed to close response body: %v", err)
+		}
+	}()
+	
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("Expected status %d, got %d", http.StatusServiceUnavailable, resp.StatusCode)
+	}
+	
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+	
+	expected := "Not Ready"
+	if string(body) != expected {
+		t.Errorf("Expected body %q, got %q", expected, string(body))
+	}
+	
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != "text/plain" {
+		t.Errorf("Expected Content-Type 'text/plain', got %q", contentType)
+	}
+}
+
+func TestAgent_handleReadiness_Ready(t *testing.T) {
+	agent := New(nil)
+	agent.setReady(true)
+	
+	req := httptest.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	
+	agent.handleReadiness(w, req)
+	
+	resp := w.Result()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("Failed to close response body: %v", err)
+		}
+	}()
+	
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+	
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+	
+	expected := "Ready"
+	if string(body) != expected {
+		t.Errorf("Expected body %q, got %q", expected, string(body))
+	}
+	
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != "text/plain" {
+		t.Errorf("Expected Content-Type 'text/plain', got %q", contentType)
+	}
+}
+
+func TestAgent_ReadinessStateTransitions(t *testing.T) {
+	agent := New(nil)
+	
+	// Initial state should be not ready
+	if agent.isReady() {
+		t.Error("Agent should not be ready initially")
+	}
+	
+	// Set ready
+	agent.setReady(true)
+	if !agent.isReady() {
+		t.Error("Agent should be ready after setReady(true)")
+	}
+	
+	// Set not ready
+	agent.setReady(false)
+	if agent.isReady() {
+		t.Error("Agent should not be ready after setReady(false)")
+	}
+}
+
+func TestAgent_ReadinessConcurrency(t *testing.T) {
+	agent := New(nil)
+	
+	var wg sync.WaitGroup
+	
+	// Start multiple goroutines that set readiness
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(ready bool) {
+			defer wg.Done()
+			agent.setReady(ready)
+		}(i%2 == 0)
+	}
+	
+	// Start multiple goroutines that check readiness
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = agent.isReady()
+		}()
+	}
+	
+	wg.Wait()
+	// Test should complete without race conditions
+}
+
+func TestAgent_HealthEndpointsInMetricsServer(t *testing.T) {
+	agent := New(nil)
+	
+	// Create a test server using the same mux configuration as the agent
+	mux := http.NewServeMux()
+	mux.HandleFunc("/livez", agent.handleLiveness)
+	mux.HandleFunc("/readyz", agent.handleReadiness)
+	
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	
+	// Test liveness endpoint
+	resp, err := http.Get(server.URL + "/livez")
+	if err != nil {
+		t.Fatalf("Failed to call liveness endpoint: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("Failed to close response body: %v", err)
+	}
+	
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Liveness endpoint returned %d, expected %d", resp.StatusCode, http.StatusOK)
+	}
+	
+	// Test readiness endpoint (should be not ready initially)
+	resp, err = http.Get(server.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("Failed to call readiness endpoint: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("Failed to close response body: %v", err)
+	}
+	
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("Readiness endpoint returned %d, expected %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	
+	// Set agent as ready and test again
+	agent.setReady(true)
+	
+	resp, err = http.Get(server.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("Failed to call readiness endpoint after setting ready: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("Failed to close response body: %v", err)
+	}
+	
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Readiness endpoint returned %d after setting ready, expected %d", resp.StatusCode, http.StatusOK)
 	}
 }


### PR DESCRIPTION
Implement dedicated HTTP endpoints for Kubernetes liveness and readiness probes:

- /livez: Returns 200 OK when agent process is running and responsive
- /readyz: Returns 200 OK only when agent is initialized and can communicate with API

Features:
- Thread-safe readiness state management with RWMutex
- Proper integration with existing metrics server on port 8080
- Readiness callback mechanism in worker for API communication status
- Comprehensive test coverage including unit and integration tests
- Proper error handling and logging throughout

The readiness endpoint reflects agent initialization state:
- Returns 503 during startup or when API communication fails
- Returns 200 after successful initial API communication
- Handles standalone mode (no API configured) appropriately