### PR TITLE
Various minor `internal/agent` and `internal/k8s` package iterations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ go.work.sum
 # .vscode/
 
 test/e2e/data/
-agent
+rhobs-synthetics-agent

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -25,6 +25,12 @@ type ResourceManager struct {
 	mu          sync.Mutex
 }
 
+type ResourceType string
+const (
+	ResourceTypeFile       = "file"
+	ResourceTypeConnection = "connection"
+)
+
 // NewResourceManager creates a new resource manager
 func NewResourceManager() *ResourceManager {
 	return &ResourceManager{
@@ -35,14 +41,14 @@ func NewResourceManager() *ResourceManager {
 }
 
 // AddResource adds a resource to be tracked and cleaned up
-func (rm *ResourceManager) AddResource(resource io.Closer, resourceType string) {
+func (rm *ResourceManager) AddResource(resource io.Closer, resourceType ResourceType) {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 
 	switch resourceType {
-	case "file":
+	case ResourceTypeFile:
 		rm.openFiles = append(rm.openFiles, resource)
-	case "connection":
+	case ResourceTypeConnection:
 		rm.connections = append(rm.connections, resource)
 	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -60,7 +60,7 @@ func TestResourceManager_AddResource(t *testing.T) {
 	connCloser := &mockCloser{}
 
 	// Test adding file resource
-	rm.AddResource(fileCloser, "file")
+	rm.AddResource(fileCloser, ResourceTypeFile)
 	if len(rm.openFiles) != 1 {
 		t.Errorf("Expected 1 file resource, got %d", len(rm.openFiles))
 	}
@@ -69,7 +69,7 @@ func TestResourceManager_AddResource(t *testing.T) {
 	}
 
 	// Test adding connection resource
-	rm.AddResource(connCloser, "connection")
+	rm.AddResource(connCloser, ResourceTypeConnection)
 	if len(rm.openFiles) != 1 {
 		t.Errorf("Expected 1 file resource, got %d", len(rm.openFiles))
 	}
@@ -97,10 +97,10 @@ func TestResourceManager_Cleanup(t *testing.T) {
 	connCloser1 := &mockCloser{}
 	connCloser2 := &mockCloser{}
 
-	rm.AddResource(fileCloser1, "file")
-	rm.AddResource(fileCloser2, "file")
-	rm.AddResource(connCloser1, "connection")
-	rm.AddResource(connCloser2, "connection")
+	rm.AddResource(fileCloser1, ResourceTypeFile)
+	rm.AddResource(fileCloser2, ResourceTypeFile)
+	rm.AddResource(connCloser1, ResourceTypeConnection)
+	rm.AddResource(connCloser2, ResourceTypeConnection)
 
 	// Call cleanup
 	rm.Cleanup()
@@ -127,8 +127,8 @@ func TestResourceManager_Cleanup_WithErrors(t *testing.T) {
 	failingCloser := &mockCloser{err: io.ErrClosedPipe}
 	normalCloser := &mockCloser{}
 
-	rm.AddResource(failingCloser, "file")
-	rm.AddResource(normalCloser, "connection")
+	rm.AddResource(failingCloser, ResourceTypeFile)
+	rm.AddResource(normalCloser, ResourceTypeConnection)
 
 	// Cleanup should not panic even if some resources fail to close
 	rm.Cleanup()
@@ -165,7 +165,7 @@ func TestResourceManager_ConcurrentAccess(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			closer := &mockCloser{}
-			rm.AddResource(closer, "file")
+			rm.AddResource(closer, ResourceTypeFile)
 		}()
 	}
 
@@ -410,7 +410,7 @@ func BenchmarkResourceManager_AddResource(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		rm.AddResource(closers[i], "file")
+		rm.AddResource(closers[i], ResourceTypeFile)
 	}
 }
 
@@ -420,7 +420,7 @@ func BenchmarkResourceManager_Cleanup(b *testing.B) {
 		rm := NewResourceManager()
 		// Add 100 resources
 		for j := 0; j < 100; j++ {
-			rm.AddResource(&mockCloser{}, "file")
+			rm.AddResource(&mockCloser{}, ResourceTypeFile)
 		}
 		b.StartTimer()
 

--- a/internal/agent/worker.go
+++ b/internal/agent/worker.go
@@ -13,6 +13,8 @@ import (
 	"github.com/rhobs/rhobs-synthetics-agent/internal/metrics"
 )
 
+const defaultProbeNamespace = "default"
+
 type Worker struct {
 	config          *Config
 	apiClients      []*api.Client
@@ -22,8 +24,9 @@ type Worker struct {
 
 func NewWorker(cfg *Config) *Worker {
 	var apiClients []*api.Client
-	var probeManager *k8s.ProbeManager
 
+	namespace := defaultProbeNamespace
+	kubeConfigPath := ""
 	if cfg != nil {
 		// Create API clients for each configured URL
 		apiURLs := cfg.GetAPIBaseURLs()
@@ -34,14 +37,15 @@ func NewWorker(cfg *Config) *Worker {
 			}
 		}
 
-		namespace := cfg.Namespace
-		if namespace == "" {
-			namespace = "default"
+		if cfg.Namespace != "" {
+			namespace = cfg.Namespace
 		}
-		probeManager = k8s.NewProbeManager(namespace, cfg.KubeConfig)
-	} else {
-		probeManager = k8s.NewProbeManager("default", "")
+		if cfg.KubeConfig != "" {
+			kubeConfigPath = cfg.KubeConfig
+		}
 	}
+
+	probeManager := k8s.NewProbeManager(namespace, kubeConfigPath)
 
 	return &Worker{
 		config:          cfg,

--- a/internal/k8s/probe_test.go
+++ b/internal/k8s/probe_test.go
@@ -151,7 +151,7 @@ func TestProbeManager_initializeK8sClients(t *testing.T) {
 	pm := NewProbeManager("test-namespace", "")
 
 	// After initialization, check state
-	if pm.isK8sCluster {
+	if pm.isK8sCluster() {
 		// If we're actually in a K8s cluster
 		if pm.kubeClient == nil {
 			t.Error("kubeClient should not be nil when in K8s cluster")
@@ -225,7 +225,6 @@ func TestProbeManager_checkProbeCRDs_NoClient(t *testing.T) {
 		namespace:     "test",
 		httpClient:    &http.Client{},
 		kubeClient:    nil,
-		isK8sCluster:  false,
 		probeAPIGroup: "",
 	}
 


### PR DESCRIPTION
This PR contains several minor changes to the `internal/agent` and `internal/k8s` packages, as well as an update to the `.gitignore` file.

In summary:
- Updates the `.gitignore` to ignore `rhobs-synthetics-agent`, rather than `agent`. Ignoring `agent` causes git to print warnings when adding files from the `internal/agent` package.
- Simplifies the ProbeManager structure. The `kubeconfigPath` field has been removed, since, at present, it is only used during initialization. The `isK8sCluster` field was replaced with a method of the same name: rather than tracking state within the object, we can just evaluate whether a k8sClient was created upon initialization. 
- Adds a `ResourceType` type to the `internal/agent` package to avoid using hardcoded strings when interacting with the `ResourceManager` struct
- Minor reorganization of the `internal/agent.Worker` constructor logic to DRY it out 