### PR TITLE
allow setting api-endpoint from cli

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -59,9 +59,10 @@ func main() {
 	startCmd.Flags().String("graceful-timeout", "30s", "Graceful shutdown timeout")
 	startCmd.Flags().String("kubeconfig", "", "Path to kubeconfig file (optional, for out-of-cluster development)")
 	startCmd.Flags().String("namespace", "default", "The Kubernetes namespace for probe resources")
-	
+
 	// API Config flags
 	startCmd.Flags().StringSlice("api-base-urls", []string{}, "Comma-separated list of base URLs for observatorium APIs")
+	startCmd.Flags().String("api-endpoint", "/api/metrics/v1", "API endpoint for synthetics")
 	startCmd.Flags().String("api-tenant", "default", "API tenant identifier")
 
 	// Bind flags to viper
@@ -72,6 +73,7 @@ func main() {
 	_ = viper.BindPFlag("kube_config", startCmd.Flags().Lookup("kubeconfig"))
 	_ = viper.BindPFlag("namespace", startCmd.Flags().Lookup("namespace"))
 	_ = viper.BindPFlag("api_base_urls", startCmd.Flags().Lookup("api-base-urls"))
+	_ = viper.BindPFlag("api_endpoint", startCmd.Flags().Lookup("api-endpoint"))
 	_ = viper.BindPFlag("api_tenant", startCmd.Flags().Lookup("api-tenant"))
 
 	// Add commands to the root command


### PR DESCRIPTION
# Overview

Allow setting `--api-endpoint` from the CLI so you can start a local agent for local dev:
```
$ go run cmd/agent/main.go start --api-base-urls http://localhost:8888 --api-endpoint /probes

{"time":"2025-08-26T14:19:45.293819-04:00","level":"INFO","msg":"RHOBS Synthetic Agent started with config: LogLevel=info, LogFormat=json, PollingInterval=30s, GracefulTimeout=30s, APIBaseURLs=[http://localhost:8888]"}
{"time":"2025-08-26T14:19:45.293963-04:00","level":"INFO","msg":"Starting metrics server on :8080 with /metrics, /livez, and /readyz endpoints"}
{"time":"2025-08-26T14:19:45.294048-04:00","level":"INFO","msg":"RHOBS Synthetic Agent worker thread started"}
{"time":"2025-08-26T14:19:45.29407-04:00","level":"INFO","msg":"Configured 1 API endpoint(s) for probe processing"}
{"time":"2025-08-26T14:19:45.294075-04:00","level":"INFO","msg":"Starting probe reconciliation cycle"}
{"time":"2025-08-26T14:19:45.294078-04:00","level":"INFO","msg":"Fetching probe list from 1 API endpoints with label selector: private=false,rhobs-synthetics/status=pending"}
{"time":"2025-08-26T14:19:45.294081-04:00","level":"INFO","msg":"Fetching probes from API endpoint 1/1"}
{"time":"2025-08-26T14:19:45.301727-04:00","level":"INFO","msg":"Successfully fetched 0 probes from API endpoint 1"}
{"time":"2025-08-26T14:19:45.301751-04:00","level":"INFO","msg":"Successfully fetched 0 total probes (0 unique) from 1 API endpoints"}
{"time":"2025-08-26T14:19:45.301754-04:00","level":"INFO","msg":"No pending probes found"}
```