### PR TITLE
SREP-830 - Initial Blackbox deployment logic

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -47,7 +47,11 @@ func main() {
 			// Reinitialize logger with viper configuration to catch the log level flag
 			logger.ReinitLogger()
 
-			agent := agent.New(cfg)
+			agent, err := agent.New(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to initialize agent: %w", err)
+			}
+
 			return agent.Run()
 		},
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -26,8 +26,11 @@ type Agent struct {
 	readyMu         sync.RWMutex
 }
 
-func New(cfg *Config) *Agent {
-	worker := NewWorker(cfg)
+func New(cfg *Config) (*Agent, error) {
+	worker, err := NewWorker(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize worker: %w", err)
+	}
 
 	// Initialize agent info metrics
 	namespace := "default"
@@ -46,7 +49,7 @@ func New(cfg *Config) *Agent {
 	// Set readiness callback for the worker
 	worker.SetReadinessCallback(agent.setReady)
 
-	return agent
+	return agent, nil
 }
 
 func (a *Agent) Run() error {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -18,7 +18,10 @@ func TestNew(t *testing.T) {
 		GracefulTimeout: 30 * time.Second,
 	}
 
-	agent := New(cfg)
+	agent, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 
 	if agent == nil {
 		t.Fatal("New() returned nil")
@@ -46,7 +49,10 @@ func TestNew(t *testing.T) {
 }
 
 func TestNew_NilConfig(t *testing.T) {
-	agent := New(nil)
+	agent, err := New(nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 
 	if agent == nil {
 		t.Fatal("New() returned nil with nil config")
@@ -70,7 +76,10 @@ func TestAgent_Run_QuickShutdown(t *testing.T) {
 		GracefulTimeout: 100 * time.Millisecond,
 	}
 
-	agent := New(cfg)
+	agent, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 
 	// Test the shutdown channel mechanism directly
 	done := make(chan error, 1)
@@ -109,13 +118,16 @@ func TestAgent_startHealthServer(t *testing.T) {
 		GracefulTimeout: 30 * time.Second,
 	}
 
-	agent := New(cfg)
+	agent, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
 	// startMetricsServer should block until context is cancelled
-	err := agent.startMetricsServer(ctx)
+	err = agent.startMetricsServer(ctx)
 
 	// Should return nil when context is cancelled
 	if err != nil {
@@ -131,7 +143,10 @@ func TestAgent_TaskWaitGroup(t *testing.T) {
 		GracefulTimeout: 200 * time.Millisecond,
 	}
 
-	agent := New(cfg)
+	agent, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 
 	// Test that we can track a task with the wait group
 	agent.taskWG.Add(1)
@@ -163,7 +178,10 @@ func TestAgent_Config_String_Integration(t *testing.T) {
 		GracefulTimeout: 60 * time.Second,
 	}
 
-	agent := New(cfg)
+	agent, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 
 	// Verify the config string formatting works with the agent
 	expected := "LogLevel=debug, LogFormat=text, PollingInterval=45s, GracefulTimeout=1m0s, APIURLs=[]"
@@ -190,7 +208,10 @@ func TestAgent_ShutdownChannel_State(t *testing.T) {
 		GracefulTimeout: 1 * time.Second,
 	}
 
-	agent := New(cfg)
+	agent, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 
 	// Initially, shutdown channel should be open
 	if isClosed(agent.shutdownChan) {
@@ -198,7 +219,10 @@ func TestAgent_ShutdownChannel_State(t *testing.T) {
 	}
 
 	// Create a new agent to test closing behavior (avoid double close)
-	agent2 := New(cfg)
+	agent2, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 
 	// After closing, it should be closed
 	close(agent2.shutdownChan)
@@ -223,7 +247,10 @@ func BenchmarkConfig_String(b *testing.B) {
 }
 
 func TestAgent_handleLiveness(t *testing.T) {
-	agent := New(nil)
+	agent, err := New(nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 	
 	req := httptest.NewRequest("GET", "/livez", nil)
 	w := httptest.NewRecorder()
@@ -258,7 +285,10 @@ func TestAgent_handleLiveness(t *testing.T) {
 }
 
 func TestAgent_handleReadiness_NotReady(t *testing.T) {
-	agent := New(nil)
+	agent, err := New(nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 	// Agent starts as not ready
 	
 	req := httptest.NewRequest("GET", "/readyz", nil)
@@ -294,7 +324,10 @@ func TestAgent_handleReadiness_NotReady(t *testing.T) {
 }
 
 func TestAgent_handleReadiness_Ready(t *testing.T) {
-	agent := New(nil)
+	agent, err := New(nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 	agent.setReady(true)
 	
 	req := httptest.NewRequest("GET", "/readyz", nil)
@@ -330,7 +363,10 @@ func TestAgent_handleReadiness_Ready(t *testing.T) {
 }
 
 func TestAgent_ReadinessStateTransitions(t *testing.T) {
-	agent := New(nil)
+	agent, err := New(nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 	
 	// Initial state should be not ready
 	if agent.isReady() {
@@ -351,7 +387,10 @@ func TestAgent_ReadinessStateTransitions(t *testing.T) {
 }
 
 func TestAgent_ReadinessConcurrency(t *testing.T) {
-	agent := New(nil)
+	agent, err := New(nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 	
 	var wg sync.WaitGroup
 	
@@ -378,7 +417,10 @@ func TestAgent_ReadinessConcurrency(t *testing.T) {
 }
 
 func TestAgent_HealthEndpointsInMetricsServer(t *testing.T) {
-	agent := New(nil)
+	agent, err := New(nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating agent: %v", err)
+	}
 	
 	// Create a test server using the same mux configuration as the agent
 	mux := http.NewServeMux()

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rhobs/rhobs-synthetics-agent/internal/k8s"
 	"github.com/spf13/viper"
 )
 
@@ -24,14 +25,7 @@ type Config struct {
 	Namespace       string `mapstructure:"namespace"`
 	
 	// Blackbox Configuration
-	Blackbox BlackboxConfig `mapstructure:"blackbox"`
-}
-
-// BlackboxConfig holds configuration for blackbox exporter probes
-type BlackboxConfig struct {
-	Interval  string `mapstructure:"interval"`
-	Module    string `mapstructure:"module"`
-	ProberURL string `mapstructure:"prober_url"`
+	Blackbox k8s.BlackboxConfig `mapstructure:"blackbox"`
 }
 
 // GetAPIURLs returns the list of complete API URLs
@@ -56,11 +50,8 @@ func LoadConfig() (*Config, error) {
 	viper.SetDefault("jwt_token", "")
 	viper.SetDefault("kube_config", "")
 	viper.SetDefault("namespace", "default")
-	
-	// Blackbox defaults
-	viper.SetDefault("blackbox.interval", "30s")
-	viper.SetDefault("blackbox.module", "http_2xx")
-	viper.SetDefault("blackbox.prober_url", "http://blackbox-exporter:9115")
+
+	k8s.LoadBlackboxDefaults()
 
 	viper.AutomaticEnv()
 

--- a/internal/k8s/config.go
+++ b/internal/k8s/config.go
@@ -1,0 +1,31 @@
+package k8s
+
+import "github.com/spf13/viper"
+
+type BlackboxConfig struct {
+	Probing    BlackboxProbingConfig    `mapstructure:"probing"`
+	Deployment BlackboxDeploymentConfig `mapstructure:"deployment"`
+}
+
+type BlackboxProbingConfig struct {
+	Interval  string `mapstructure:"interval"`
+	Module    string `mapstructure:"module"`
+	ProberURL string `mapstructure:"prober_url"`
+}
+
+type BlackboxDeploymentConfig struct {
+	Image  string            `mapstructure:"image"`
+	Cmd    []string          `mapstructure:"command"`
+	Args   []string          `mapstructure:"args"`
+	Labels map[string]string `mapstructure:"custom_labels"`
+}
+
+func LoadBlackboxDefaults() {
+	viper.SetDefault("blackbox.probing.interval", "30s")
+	viper.SetDefault("blackbox.probing.module", "http_2xx")
+	viper.SetDefault("blackbox.probing.prober_url", "http://blackbox-exporter:9115")
+
+	viper.SetDefault("blackbox.deployment.image", DefaultBlackBoxExporterImage)
+	viper.SetDefault("blackbox.deployment.command", []string{})
+	viper.SetDefault("blackbox.deployment.arguments", []string{})
+}

--- a/internal/k8s/probe_edge_cases_test.go
+++ b/internal/k8s/probe_edge_cases_test.go
@@ -103,7 +103,7 @@ func TestProbeManager_CreateProbeResource_MissingLabels(t *testing.T) {
 		Status:    "pending",
 	}
 
-	probeConfig := ProbeConfig{
+	probeConfig := BlackboxProbingConfig{
 		Interval:  "30s",
 		Module:    "http_2xx",
 		ProberURL: "http://blackbox-exporter:9115",
@@ -144,7 +144,7 @@ func TestProbeManager_CreateProbeResource_PartialLabels(t *testing.T) {
 		Status: "pending",
 	}
 
-	probeConfig := ProbeConfig{
+	probeConfig := BlackboxProbingConfig{
 		Interval:  "30s",
 		Module:    "http_2xx",
 		ProberURL: "http://blackbox-exporter:9115",

--- a/internal/k8s/probe_test.go
+++ b/internal/k8s/probe_test.go
@@ -58,7 +58,7 @@ func TestProbeManager_CreateProbeResource(t *testing.T) {
 		Status: "pending",
 	}
 
-	probeConfig := ProbeConfig{
+	probeConfig := BlackboxProbingConfig{
 		Interval:  "30s",
 		Module:    "http_2xx",
 		ProberURL: "http://blackbox-exporter:9115",
@@ -123,7 +123,7 @@ func TestProbeManager_CreateProbeResource_InvalidURL(t *testing.T) {
 		Status: "pending",
 	}
 
-	probeConfig := ProbeConfig{
+	probeConfig := BlackboxProbingConfig{
 		Interval:  "30s",
 		Module:    "http_2xx",
 		ProberURL: "http://blackbox-exporter:9115",
@@ -185,7 +185,7 @@ func TestProbeManager_CreateProbeK8sResource_NotInCluster(t *testing.T) {
 		Status: "pending",
 	}
 
-	probeConfig := ProbeConfig{
+	probeConfig := BlackboxProbingConfig{
 		Interval:  "30s",
 		Module:    "http_2xx",
 		ProberURL: "http://blackbox-exporter:9115",

--- a/internal/k8s/prober.go
+++ b/internal/k8s/prober.go
@@ -1,0 +1,186 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/rhobs/rhobs-synthetics-api/pkg/kubeclient"
+)
+
+type ProberManager interface {
+	// GetProber retrieves the given Prober
+	GetProber(ctx context.Context, name string) (p Prober, found bool, err error)
+	// CreateProber creates a Prober with the given name
+	CreateProber(ctx context.Context, name string) (p Prober, err error)
+	// DeleteProber removes a Prober with the given name
+	DeleteProber(ctx context.Context, name string) (err error)
+}
+
+const (
+	// BlackBoxProberManagerResourceType defines the Kubernetes resource-type used to run
+	// Blackbox exporter probers
+	BlackBoxProberManagerResourceType = "deployment"
+	// BlackBoxProberManagerProberLabelKey defines the label-key used to identify which Prober
+	// Kubernetes objects belong to
+	BlackBoxProberManagerProberLabelKey = "prober.synthetics-agent.rhobs"
+	// DefaultBlackBoxExporterImage defines the container image used if none is given to the BlackBoxProberManager at creation-time
+	DefaultBlackBoxExporterImage = "quay.io/prometheus/blackbox-exporter:latest"
+	// DefaultBlackBoxProberManagerNamespace defines the namespace used if none is provided when creating a new BlackBoxProberManager.
+	DefaultBlackBoxProberManagerNamespace = "default"
+)
+
+type BlackBoxProberManager struct {
+	// kubeClient allows the BlackBoxProberManager to interact with a Kubernetes cluster
+	kubeClient *kubeclient.Client
+	// namespace denotes the namespace the ProberManager is operating under
+	namespace string
+	// cfg defines the BlackBoxProberManager's configuration. All BlackBoxProbers managed by
+	// this BlackBoxProberManager will be subject to this configuration
+	cfg BlackboxDeploymentConfig
+}
+
+//func NewBlackBoxProberManager(namespace string, kubeconfigPath string, opts... BlackBoxProberOption) (*BlackBoxProberManager, error) {
+func NewBlackBoxProberManager(namespace string, kubeconfigPath string, cfg BlackboxDeploymentConfig) (*BlackBoxProberManager, error) {
+	if kubeconfigPath == "" {
+		return nil, fmt.Errorf("kubeconfig path must be specified")
+	}
+	client, err := kubeclient.NewClient(kubeclient.Config{KubeconfigPath: kubeconfigPath})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Kubernetes client: %w", err)
+	}
+
+	if namespace == "" {
+		namespace = DefaultBlackBoxProberManagerNamespace
+	}
+
+	manager := &BlackBoxProberManager{
+		kubeClient: client,
+		namespace:  namespace,
+		cfg:        cfg,
+	}
+	return manager, nil
+}
+
+// deploymentClient is a helper function to interact with appsv1.Deployment objects in the namespace specified
+// in the BlackBoxProberManager's config
+func (m *BlackBoxProberManager) deploymentClient() dynamic.ResourceInterface {
+	return m.kubeClient.DynamicClient().Resource(appsv1.SchemeGroupVersion.WithResource("deployments")).Namespace(m.namespace)
+}
+
+func (m *BlackBoxProberManager) GetProber(ctx context.Context, name string) (p Prober, found bool, err error) {
+	deploymentName := m.proberDeploymentName(name)
+	unstruct, err := m.deploymentClient().Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		if kerr.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to GET prober deployment %q: %w", fmt.Sprintf("%s/%s", m.namespace, deploymentName), err)
+	}
+
+	deployment, err := convertUnstructuredToDeployment(unstruct)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to convert unstructured object to deployment object: %w", err)
+	}
+
+	p = &BlackBoxProber{
+		deployment: *deployment,
+	}
+	return p, true, nil
+}
+
+func (m *BlackBoxProberManager) CreateProber(ctx context.Context, name string) (Prober, error) {
+	deployment := m.buildProberDeployment(name)
+	unstructuredProber, err := convertToUnstructured(&deployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert deployment to unstructured object: %w", err)
+	}
+
+	unstructuredResult, err := m.deploymentClient().Create(ctx, unstructuredProber, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to CREATE prober deployment %q: %w", fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name), err)
+	}
+
+	result, err := convertUnstructuredToDeployment(unstructuredResult)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert unstructured object to deployment object: %w", err)
+	}
+	return result, nil
+}
+
+func (m *BlackBoxProberManager) DeleteProber(ctx context.Context, name string) error {
+	return nil
+}
+
+func (m *BlackBoxProberManager) buildProberDeployment(proberName string) appsv1.Deployment {
+	replicas := int32(1)
+	labels := m.proberCustomLabels()
+	labels[BlackBoxProberManagerProberLabelKey] = proberName
+
+	deployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.proberDeploymentName(proberName),
+			Namespace: m.namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{BlackBoxProberManagerProberLabelKey: proberName},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "prober",
+							Image:   m.cfg.Image,
+							Command: m.cfg.Cmd,
+							Args:    m.cfg.Args,
+						},
+					},
+				},
+			},
+		},
+	}
+	return deployment
+}
+
+// proberDeploymentName generates the standardized name for a BlackBoxProber's deployment
+func (m *BlackBoxProberManager) proberDeploymentName(name string) string {
+	return fmt.Sprintf("synthetics-agent-%s", name)
+}
+
+// proberCustomLabels retrieves the custom deployment labels specified by the BlackBoxProberManager's config.
+// If none are defined, a non-nil empty map is returned
+func (m *BlackBoxProberManager) proberCustomLabels() map[string]string {
+	labels := m.cfg.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	return labels
+}
+
+// Prober implementations define the operands which measure the availability of endpoints
+type Prober interface{
+	String() string
+}
+
+// BlackBoxProber defines a Prober which measures endpoint availability via BlackBox Exporter
+// deployments
+type BlackBoxProber struct {
+	deployment appsv1.Deployment
+}
+
+// String prints a uniquely-identifying string for the BlackBoxProber
+func (p *BlackBoxProber) String() string {
+	return fmt.Sprintf("apps/v1/deployment/%s/%s", p.deployment.Namespace, p.deployment.Name)
+}

--- a/test/e2e/e2e_real_api_test.go
+++ b/test/e2e/e2e_real_api_test.go
@@ -39,7 +39,10 @@ func TestAgent_E2E_WithRealAPI(t *testing.T) {
 	}
 
 	// Create and start agent
-	testAgent := agent.New(cfg)
+	testAgent, err := agent.New(cfg)
+	if err != nil {
+		t.Fatalf("failed to start test agent: %v", err)
+	}
 
 	// Run agent in background
 	var wg sync.WaitGroup
@@ -192,7 +195,10 @@ func TestAgent_E2E_RealAPI_ErrorHandling(t *testing.T) {
 			LabelSelector:   "env=test",
 		}
 
-		testAgent := agent.New(cfg)
+		testAgent, err := agent.New(cfg)
+		if err != nil {
+			t.Fatalf("failed to start test agent: %v", err)
+		}
 
 		// Run agent briefly
 		var agentErr error
@@ -277,7 +283,10 @@ func TestAgent_E2E_RealAPI_ConfigurationVariations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testAgent := agent.New(tc.config)
+			testAgent, err := agent.New(tc.config)
+			if err != nil {
+				t.Fatalf("failed to start test agent: %v", err)
+			}
 
 			var wg sync.WaitGroup
 			wg.Add(1)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -26,7 +26,10 @@ func TestAgent_E2E_WithAPI(t *testing.T) {
 	}
 
 	// Create and start agent
-	testAgent := agent.New(cfg)
+	testAgent, err := agent.New(cfg)
+	if err != nil {
+		t.Fatalf("failed to start test agent: %v", err)
+	}
 
 	// Run agent in background
 	var agentErr error
@@ -170,7 +173,10 @@ func TestAgent_E2E_ErrorHandling(t *testing.T) {
 			LabelSelector:   "env=test",
 		}
 
-		testAgent := agent.New(cfg)
+		testAgent, err := agent.New(cfg)
+		if err != nil {
+			t.Fatalf("failed to start test agent: %v", err)
+		}
 
 		// Run agent briefly
 		var agentErr error
@@ -241,7 +247,10 @@ func TestAgent_E2E_ConfigurationVariations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testAgent := agent.New(tc.config)
+			testAgent, err := agent.New(tc.config)
+			if err != nil {
+				t.Fatalf("failed to start test agent: %v", err)
+			}
 
 			var wg sync.WaitGroup
 			wg.Add(1)

--- a/test/e2e/k8s_probe_e2e_test.go
+++ b/test/e2e/k8s_probe_e2e_test.go
@@ -56,7 +56,10 @@ func TestAgent_E2E_KubernetesProbeCreation(t *testing.T) {
 	}
 
 	// Create and start agent
-	testAgent := agent.New(cfg)
+	testAgent, err := agent.New(cfg)
+	if err != nil {
+		t.Fatalf("failed to start test agent: %v", err)
+	}
 
 	// Run agent in background
 	var wg sync.WaitGroup
@@ -82,7 +85,7 @@ func TestAgent_E2E_KubernetesProbeCreation(t *testing.T) {
 	t.Run("TestProbeResourceCreation", func(t *testing.T) {
 		pm := k8s.NewProbeManager("monitoring", "")
 		
-		config := k8s.ProbeConfig{
+		config := k8s.BlackboxProbingConfig{
 			Interval:  "30s",
 			Module:    "http_2xx",
 			ProberURL: "http://blackbox-exporter:9115",
@@ -165,7 +168,7 @@ func TestAgent_E2E_KubernetesProbeCreation(t *testing.T) {
 			Status:    "pending",
 		}
 
-		config := k8s.ProbeConfig{
+		config := k8s.BlackboxProbingConfig{
 			Interval:  "30s",
 			Module:    "http_2xx",
 			ProberURL: "http://blackbox-exporter:9115",
@@ -228,7 +231,7 @@ func TestAgent_E2E_KubernetesProbeWithFakeClient(t *testing.T) {
 		// Create a custom probe manager that uses fake clients
 		pm := createTestProbeManagerWithFakeClients("monitoring", fakeKubeClient, fakeDynamicClient)
 
-		config := k8s.ProbeConfig{
+		config := k8s.BlackboxProbingConfig{
 			Interval:  "30s",
 			Module:    "http_2xx",
 			ProberURL: "http://blackbox-exporter:9115",
@@ -357,7 +360,7 @@ func TestAgent_E2E_KubernetesProbeEdgeCases(t *testing.T) {
 	testCases := []struct {
 		name        string
 		probe       api.Probe
-		config      k8s.ProbeConfig
+		config      k8s.BlackboxProbingConfig
 		expectError bool
 		errorMsg    string
 	}{
@@ -369,7 +372,7 @@ func TestAgent_E2E_KubernetesProbeEdgeCases(t *testing.T) {
 				Labels:    map[string]string{"env": "test"},
 				Status:    "pending",
 			},
-			config: k8s.ProbeConfig{
+			config: k8s.BlackboxProbingConfig{
 				Interval:  "60s",
 				Module:    "http_2xx",
 				ProberURL: "http://blackbox-exporter:9115",
@@ -391,7 +394,7 @@ func TestAgent_E2E_KubernetesProbeEdgeCases(t *testing.T) {
 				},
 				Status: "active",
 			},
-			config: k8s.ProbeConfig{
+			config: k8s.BlackboxProbingConfig{
 				Interval:  "15s",
 				Module:    "http_2xx",
 				ProberURL: "http://blackbox-exporter:9115",
@@ -406,7 +409,7 @@ func TestAgent_E2E_KubernetesProbeEdgeCases(t *testing.T) {
 				Labels:    map[string]string{"env": "test"},
 				Status:    "pending",
 			},
-			config: k8s.ProbeConfig{
+			config: k8s.BlackboxProbingConfig{
 				Interval:  "30s",
 				Module:    "http_2xx",
 				ProberURL: "http://blackbox-exporter:9115",
@@ -422,7 +425,7 @@ func TestAgent_E2E_KubernetesProbeEdgeCases(t *testing.T) {
 				Labels:    map[string]string{"env": "test"},
 				Status:    "pending",
 			},
-			config: k8s.ProbeConfig{
+			config: k8s.BlackboxProbingConfig{
 				Interval:  "30s",
 				Module:    "http_2xx",
 				ProberURL: "http://blackbox-exporter:9115",

--- a/test/e2e/metrics_e2e_test.go
+++ b/test/e2e/metrics_e2e_test.go
@@ -30,7 +30,10 @@ func TestAgent_E2E_Metrics(t *testing.T) {
 	}
 
 	// Create and start agent
-	testAgent := agent.New(cfg)
+	testAgent, err := agent.New(cfg)
+	if err != nil {
+		t.Fatalf("failed to start test agent: %v", err)
+	}
 
 	// Run agent in background
 	var agentErr error
@@ -278,7 +281,10 @@ func TestAgent_E2E_MetricsWithAPIFailure(t *testing.T) {
 		LabelSelector:   "env=test",
 	}
 
-	testAgent := agent.New(cfg)
+	testAgent, err := agent.New(cfg)
+	if err != nil {
+		t.Fatalf("failed to start test agent: %v", err)
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -349,7 +355,10 @@ func TestAgent_E2E_MetricsStandaloneMode(t *testing.T) {
 		APIURLs:         []string{}, // No API URLs - standalone mode
 	}
 
-	testAgent := agent.New(cfg)
+	testAgent, err := agent.New(cfg)
+	if err != nil {
+		t.Fatalf("failed to start test agent: %v", err)
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(1)


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-830

---

Adds the initial blackbox-exporter deployment logic to the worker's probe-processing loop. This early implementation creates a single deployment whose pods only contain a single blackbox-exporter container; enhancement PRs to follow which will add tests, the ability to shard out the agent's blackbox probers based on some config value, and a prometheus-agent sidecar container.

A high-level overview of these changes:
- `internal/agent.Worker`'s `Start()` method is updated to process probers (read: blackbox-exporters) alongside probes
- the `BlackboxConfig` structure moves from `internal/agent` -> `internal/k8s` to reduce duplication, and includes a new field `BlackboxDeploymentConfig`
- new helper methods defined to (un)marshal objects to/from `unstructured.Unstructured` types
- new struct `BlackBoxProberManager` is defined satisfying a new interface `ProberManager`
  - `ProberManager` defines generic methods (Create/Get/Delete) to interact with probing operands, which will simplify testing and allow new types of operands to be seamlessly integrated in the future
  - `BlackBoxProberManager` specifies an implementation of `ProberManager` geared around measuring availability via `blackbox-exporter` pods deployed to a Kubernetes or OpenShift cluster