### PR TITLE
Remove unused struct 'ResourceManager'

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -10,189 +10,6 @@ import (
 	"time"
 )
 
-// Mock closer for testing resource cleanup
-type mockCloser struct {
-	closed bool
-	err    error
-}
-
-func (m *mockCloser) Close() error {
-	m.closed = true
-	return m.err
-}
-
-func TestNewResourceManager(t *testing.T) {
-	rm := NewResourceManager()
-
-	if rm == nil {
-		t.Fatal("NewResourceManager() returned nil")
-	}
-
-	if rm.httpClient == nil {
-		t.Error("NewResourceManager() did not initialize httpClient")
-	}
-
-	if rm.httpClient.Timeout != 30*time.Second {
-		t.Errorf("Expected httpClient timeout to be 30s, got %v", rm.httpClient.Timeout)
-	}
-
-	if rm.openFiles == nil {
-		t.Error("NewResourceManager() did not initialize openFiles slice")
-	}
-
-	if rm.connections == nil {
-		t.Error("NewResourceManager() did not initialize connections slice")
-	}
-
-	if len(rm.openFiles) != 0 {
-		t.Error("Expected openFiles to be empty initially")
-	}
-
-	if len(rm.connections) != 0 {
-		t.Error("Expected connections to be empty initially")
-	}
-}
-
-func TestResourceManager_AddResource(t *testing.T) {
-	rm := NewResourceManager()
-
-	fileCloser := &mockCloser{}
-	connCloser := &mockCloser{}
-
-	// Test adding file resource
-	rm.AddResource(fileCloser, ResourceTypeFile)
-	if len(rm.openFiles) != 1 {
-		t.Errorf("Expected 1 file resource, got %d", len(rm.openFiles))
-	}
-	if len(rm.connections) != 0 {
-		t.Errorf("Expected 0 connection resources, got %d", len(rm.connections))
-	}
-
-	// Test adding connection resource
-	rm.AddResource(connCloser, ResourceTypeConnection)
-	if len(rm.openFiles) != 1 {
-		t.Errorf("Expected 1 file resource, got %d", len(rm.openFiles))
-	}
-	if len(rm.connections) != 1 {
-		t.Errorf("Expected 1 connection resource, got %d", len(rm.connections))
-	}
-
-	// Test adding unknown resource type (should not be added)
-	unknownCloser := &mockCloser{}
-	rm.AddResource(unknownCloser, "unknown")
-	if len(rm.openFiles) != 1 {
-		t.Errorf("Expected 1 file resource after unknown type, got %d", len(rm.openFiles))
-	}
-	if len(rm.connections) != 1 {
-		t.Errorf("Expected 1 connection resource after unknown type, got %d", len(rm.connections))
-	}
-}
-
-func TestResourceManager_Cleanup(t *testing.T) {
-	rm := NewResourceManager()
-
-	// Add some mock resources
-	fileCloser1 := &mockCloser{}
-	fileCloser2 := &mockCloser{}
-	connCloser1 := &mockCloser{}
-	connCloser2 := &mockCloser{}
-
-	rm.AddResource(fileCloser1, ResourceTypeFile)
-	rm.AddResource(fileCloser2, ResourceTypeFile)
-	rm.AddResource(connCloser1, ResourceTypeConnection)
-	rm.AddResource(connCloser2, ResourceTypeConnection)
-
-	// Call cleanup
-	rm.Cleanup()
-
-	// Verify all resources were closed
-	if !fileCloser1.closed {
-		t.Error("fileCloser1 was not closed")
-	}
-	if !fileCloser2.closed {
-		t.Error("fileCloser2 was not closed")
-	}
-	if !connCloser1.closed {
-		t.Error("connCloser1 was not closed")
-	}
-	if !connCloser2.closed {
-		t.Error("connCloser2 was not closed")
-	}
-}
-
-func TestResourceManager_Cleanup_WithErrors(t *testing.T) {
-	rm := NewResourceManager()
-
-	// Add resources that will fail to close
-	failingCloser := &mockCloser{err: io.ErrClosedPipe}
-	normalCloser := &mockCloser{}
-
-	rm.AddResource(failingCloser, ResourceTypeFile)
-	rm.AddResource(normalCloser, ResourceTypeConnection)
-
-	// Cleanup should not panic even if some resources fail to close
-	rm.Cleanup()
-
-	// Both should have been attempted to close
-	if !failingCloser.closed {
-		t.Error("failingCloser was not attempted to be closed")
-	}
-	if !normalCloser.closed {
-		t.Error("normalCloser was not closed")
-	}
-}
-
-func TestResourceManager_Cleanup_NilResources(t *testing.T) {
-	rm := NewResourceManager()
-
-	// Add nil resources (edge case)
-	rm.openFiles = append(rm.openFiles, nil)
-	rm.connections = append(rm.connections, nil)
-
-	// Should not panic
-	rm.Cleanup()
-}
-
-func TestResourceManager_ConcurrentAccess(t *testing.T) {
-	rm := NewResourceManager()
-
-	// Test concurrent access to AddResource and Cleanup
-	var wg sync.WaitGroup
-
-	// Start multiple goroutines adding resources
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			closer := &mockCloser{}
-			rm.AddResource(closer, ResourceTypeFile)
-		}()
-	}
-
-	// Start a cleanup goroutine
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		time.Sleep(10 * time.Millisecond) // Let some resources be added first
-		rm.Cleanup()
-	}()
-
-	wg.Wait()
-	// Test should complete without deadlock or panic
-}
-
-func TestResourceManager_HTTPClientTransport(t *testing.T) {
-	rm := NewResourceManager()
-
-	// Set a custom transport
-	transport := &http.Transport{}
-	rm.httpClient.Transport = transport
-
-	// Cleanup should handle the transport
-	rm.Cleanup()
-	// This mainly tests that the code doesn't panic
-}
-
 func TestNew(t *testing.T) {
 	cfg := &Config{
 		LogLevel:        "info",
@@ -213,10 +30,6 @@ func TestNew(t *testing.T) {
 
 	if agent.worker == nil {
 		t.Error("New() did not initialize worker")
-	}
-
-	if agent.resourceManager == nil {
-		t.Error("New() did not initialize resourceManager")
 	}
 
 	if agent.shutdownChan == nil {
@@ -247,10 +60,6 @@ func TestNew_NilConfig(t *testing.T) {
 	if agent.worker == nil {
 		t.Error("New() did not initialize worker even with nil config")
 	}
-
-	if agent.resourceManager == nil {
-		t.Error("New() did not initialize resourceManager even with nil config")
-	}
 }
 
 func TestAgent_Run_QuickShutdown(t *testing.T) {
@@ -268,7 +77,7 @@ func TestAgent_Run_QuickShutdown(t *testing.T) {
 	go func() {
 		// Use a longer context but trigger shutdown via channel
 		ctx := context.Background()
-		done <- agent.worker.Start(ctx, agent.resourceManager, &agent.taskWG, agent.shutdownChan)
+		done <- agent.worker.Start(ctx, &agent.taskWG, agent.shutdownChan)
 	}()
 
 	// Let it run briefly to start some work
@@ -395,36 +204,6 @@ func TestAgent_ShutdownChannel_State(t *testing.T) {
 	close(agent2.shutdownChan)
 	if !isClosed(agent2.shutdownChan) {
 		t.Error("shutdownChan should be closed after close()")
-	}
-}
-
-// Benchmark tests
-func BenchmarkResourceManager_AddResource(b *testing.B) {
-	rm := NewResourceManager()
-	closers := make([]*mockCloser, b.N)
-
-	for i := 0; i < b.N; i++ {
-		closers[i] = &mockCloser{}
-	}
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		rm.AddResource(closers[i], ResourceTypeFile)
-	}
-}
-
-func BenchmarkResourceManager_Cleanup(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		rm := NewResourceManager()
-		// Add 100 resources
-		for j := 0; j < 100; j++ {
-			rm.AddResource(&mockCloser{}, ResourceTypeFile)
-		}
-		b.StartTimer()
-
-		rm.Cleanup()
 	}
 }
 

--- a/internal/agent/worker.go
+++ b/internal/agent/worker.go
@@ -60,7 +60,7 @@ func (w *Worker) SetReadinessCallback(callback func(bool)) {
 	w.readinessCallback = callback
 }
 
-func (w *Worker) Start(ctx context.Context, resourceMgr *ResourceManager, taskWG *sync.WaitGroup, shutdownChan chan struct{}) error {
+func (w *Worker) Start(ctx context.Context, taskWG *sync.WaitGroup, shutdownChan chan struct{}) error {
 	logger.Info("RHOBS Synthetic Agent worker thread started")
 
 	if len(w.apiClients) == 0 {
@@ -76,7 +76,7 @@ func (w *Worker) Start(ctx context.Context, resourceMgr *ResourceManager, taskWG
 	defer ticker.Stop()
 
 	// Initial run
-	if err := w.processProbes(ctx, resourceMgr, taskWG, shutdownChan); err != nil {
+	if err := w.processProbes(ctx, taskWG, shutdownChan); err != nil {
 		logger.Errorf("initial work failed: %v\n", err)
 		w.readinessCallback(false)
 	} else if len(w.apiClients) > 0 {
@@ -101,7 +101,7 @@ func (w *Worker) Start(ctx context.Context, resourceMgr *ResourceManager, taskWG
 			default:
 			}
 
-			if err := w.processProbes(ctx, resourceMgr, taskWG, shutdownChan); err != nil {
+			if err := w.processProbes(ctx, taskWG, shutdownChan); err != nil {
 				logger.Errorf("work iteration failed: %v\n", err)
 				// Continue running even if one iteration fails
 			}
@@ -109,7 +109,7 @@ func (w *Worker) Start(ctx context.Context, resourceMgr *ResourceManager, taskWG
 	}
 }
 
-func (w *Worker) processProbes(ctx context.Context, resourceMgr *ResourceManager, taskWG *sync.WaitGroup, shutdownChan chan struct{}) error {
+func (w *Worker) processProbes(ctx context.Context, taskWG *sync.WaitGroup, shutdownChan chan struct{}) error {
 	// Check if shutdown is in progress before starting new tasks
 	select {
 	case <-shutdownChan:

--- a/internal/agent/worker_integration_test.go
+++ b/internal/agent/worker_integration_test.go
@@ -133,7 +133,6 @@ func TestWorker_FullIntegration(t *testing.T) {
 	}
 
 	worker := NewWorker(cfg)
-	resourceMgr := NewResourceManager()
 	var taskWG sync.WaitGroup
 	shutdownChan := make(chan struct{})
 
@@ -141,7 +140,7 @@ func TestWorker_FullIntegration(t *testing.T) {
 	defer cancel()
 
 	// Run worker for a short time
-	err := worker.Start(ctx, resourceMgr, &taskWG, shutdownChan)
+	err := worker.Start(ctx, &taskWG, shutdownChan)
 	if err == nil {
 		t.Error("Expected context timeout error")
 	}
@@ -194,12 +193,11 @@ func TestWorker_processProbes_WithValidConfig(t *testing.T) {
 	}
 
 	worker := NewWorker(cfg)
-	resourceMgr := NewResourceManager()
 	var taskWG sync.WaitGroup
 	shutdownChan := make(chan struct{})
 
 	ctx := context.Background()
-	err := worker.processProbes(ctx, resourceMgr, &taskWG, shutdownChan)
+	err := worker.processProbes(ctx, &taskWG, shutdownChan)
 	if err != nil {
 		t.Errorf("processProbes() failed: %v", err)
 	}

--- a/internal/agent/worker_test.go
+++ b/internal/agent/worker_test.go
@@ -49,7 +49,6 @@ func TestWorker_Start_ContextCancellation(t *testing.T) {
 	}
 
 	worker := NewWorker(cfg)
-	resourceMgr := NewResourceManager()
 	var taskWG sync.WaitGroup
 	shutdownChan := make(chan struct{})
 
@@ -58,7 +57,7 @@ func TestWorker_Start_ContextCancellation(t *testing.T) {
 	defer cancel()
 
 	// Start the worker
-	err := worker.Start(ctx, resourceMgr, &taskWG, shutdownChan)
+	err := worker.Start(ctx, &taskWG, shutdownChan)
 
 	// Should return context.DeadlineExceeded or context.Canceled
 	if err == nil {
@@ -73,7 +72,6 @@ func TestWorker_Start_ShutdownSignal(t *testing.T) {
 	}
 
 	worker := NewWorker(cfg)
-	resourceMgr := NewResourceManager()
 	var taskWG sync.WaitGroup
 	shutdownChan := make(chan struct{})
 
@@ -82,7 +80,7 @@ func TestWorker_Start_ShutdownSignal(t *testing.T) {
 	// Start the worker in a goroutine
 	done := make(chan error, 1)
 	go func() {
-		done <- worker.Start(ctx, resourceMgr, &taskWG, shutdownChan)
+		done <- worker.Start(ctx, &taskWG, shutdownChan)
 	}()
 
 	// Send shutdown signal after a short delay
@@ -107,7 +105,6 @@ func TestWorker_Start_PollingInterval(t *testing.T) {
 	}
 
 	worker := NewWorker(cfg)
-	resourceMgr := NewResourceManager()
 	var taskWG sync.WaitGroup
 	shutdownChan := make(chan struct{})
 
@@ -116,7 +113,7 @@ func TestWorker_Start_PollingInterval(t *testing.T) {
 
 	// Start worker
 	startTime := time.Now()
-	err := worker.Start(ctx, resourceMgr, &taskWG, shutdownChan)
+	err := worker.Start(ctx, &taskWG, shutdownChan)
 
 	// Should have run for approximately the context timeout duration
 	elapsed := time.Since(startTime)
@@ -136,14 +133,13 @@ func TestWorker_processProbes(t *testing.T) {
 	}
 
 	worker := NewWorker(cfg)
-	resourceMgr := NewResourceManager()
 	var taskWG sync.WaitGroup
 	shutdownChan := make(chan struct{})
 
 	ctx := context.Background()
 
 	// Test normal processing
-	err := worker.processProbes(ctx, resourceMgr, &taskWG, shutdownChan)
+	err := worker.processProbes(ctx, &taskWG, shutdownChan)
 	if err != nil {
 		t.Errorf("processProbes() returned unexpected error: %v", err)
 	}
@@ -159,7 +155,6 @@ func TestWorker_processProbes_ShutdownSignal(t *testing.T) {
 	}
 
 	worker := NewWorker(cfg)
-	resourceMgr := NewResourceManager()
 	var taskWG sync.WaitGroup
 	shutdownChan := make(chan struct{})
 
@@ -168,7 +163,7 @@ func TestWorker_processProbes_ShutdownSignal(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := worker.processProbes(ctx, resourceMgr, &taskWG, shutdownChan)
+	err := worker.processProbes(ctx, &taskWG, shutdownChan)
 	if err != nil {
 		t.Errorf("processProbes() returned unexpected error during shutdown: %v", err)
 	}
@@ -235,7 +230,6 @@ func TestWorker_Start_InitialRun(t *testing.T) {
 	}
 
 	worker := NewWorker(cfg)
-	resourceMgr := NewResourceManager()
 	var taskWG sync.WaitGroup
 	shutdownChan := make(chan struct{})
 
@@ -244,7 +238,7 @@ func TestWorker_Start_InitialRun(t *testing.T) {
 	defer cancel()
 
 	startTime := time.Now()
-	err := worker.Start(ctx, resourceMgr, &taskWG, shutdownChan)
+	err := worker.Start(ctx, &taskWG, shutdownChan)
 	elapsed := time.Since(startTime)
 
 	// Should have completed the initial run (which takes ~1.5s total)
@@ -268,7 +262,6 @@ func TestWorker_ConcurrentShutdown(t *testing.T) {
 	}
 
 	worker := NewWorker(cfg)
-	resourceMgr := NewResourceManager()
 	var taskWG sync.WaitGroup
 	shutdownChan := make(chan struct{})
 
@@ -277,7 +270,7 @@ func TestWorker_ConcurrentShutdown(t *testing.T) {
 	// Start the worker
 	done := make(chan error, 1)
 	go func() {
-		done <- worker.Start(ctx, resourceMgr, &taskWG, shutdownChan)
+		done <- worker.Start(ctx, &taskWG, shutdownChan)
 	}()
 
 	// Let it run for a bit to start some tasks


### PR DESCRIPTION
Removes an unused struct `ResourceManager` from `internal/agent.Agent`.

This struct appears to have been intended to track open files and long-lived connections, however this is not used in practice. As a result, unneeded modules are being imported and unnecessary tests are defined that do not contribute to the overall health of the codebase.