### PR TITLE
Fix YAML syntax error in OpenShift template

### DIFF
--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -81,7 +81,7 @@ objects:
       graceful_timeout: ${GRACEFUL_TIMEOUT}
 
       # API Configuration
-      api_urls:${API_URLS}
+      api_urls: ${API_URLS}
       label_selector: ${LABEL_SELECTOR}
 
       # Kubernetes Configuration


### PR DESCRIPTION
Add missing space after colon in api_urls field to resolve "block sequence entries are not allowed in this context" error during OpenShift deployment.