### PR TITLE
Remove mutable version labels from Selectors

### DIFF
--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -13,7 +13,6 @@ objects:
       app.kubernetes.io/instance: rhobs
       app.kubernetes.io/name: synthetics-agent
       app.kubernetes.io/part-of: rhobs
-      app.kubernetes.io/version: ${IMAGE_TAG}
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
@@ -23,7 +22,6 @@ objects:
       app.kubernetes.io/instance: rhobs
       app.kubernetes.io/name: synthetics-agent
       app.kubernetes.io/part-of: rhobs
-      app.kubernetes.io/version: ${IMAGE_TAG}
   rules:
     # Access to Probe CRDs (monitoring.rhobs/v1)
     - apiGroups: ["monitoring.rhobs"]
@@ -50,7 +48,6 @@ objects:
       app.kubernetes.io/instance: rhobs
       app.kubernetes.io/name: synthetics-agent
       app.kubernetes.io/part-of: rhobs
-      app.kubernetes.io/version: ${IMAGE_TAG}
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
@@ -69,7 +66,6 @@ objects:
       app.kubernetes.io/instance: rhobs
       app.kubernetes.io/name: synthetics-agent
       app.kubernetes.io/part-of: rhobs
-      app.kubernetes.io/version: ${IMAGE_TAG}
   data:
     config.yaml: |
       # Logging configuration
@@ -102,7 +98,6 @@ objects:
       app.kubernetes.io/instance: rhobs
       app.kubernetes.io/name: synthetics-agent
       app.kubernetes.io/part-of: rhobs
-      app.kubernetes.io/version: ${IMAGE_TAG}
   spec:
     replicas: ${{REPLICA_COUNT}}
     strategy:
@@ -116,7 +111,6 @@ objects:
         app.kubernetes.io/instance: rhobs
         app.kubernetes.io/name: synthetics-agent
         app.kubernetes.io/part-of: rhobs
-        app.kubernetes.io/version: ${IMAGE_TAG}
     template:
       metadata:
         labels:
@@ -124,7 +118,6 @@ objects:
           app.kubernetes.io/instance: rhobs
           app.kubernetes.io/name: synthetics-agent
           app.kubernetes.io/part-of: rhobs
-          app.kubernetes.io/version: ${IMAGE_TAG}
       spec:
         serviceAccountName: ${APPLICATION_NAME}
         containers:
@@ -172,7 +165,6 @@ objects:
       app.kubernetes.io/instance: rhobs
       app.kubernetes.io/name: synthetics-agent
       app.kubernetes.io/part-of: rhobs
-      app.kubernetes.io/version: ${IMAGE_TAG}
   spec:
     ports:
       - name: http-metrics
@@ -184,7 +176,6 @@ objects:
       app.kubernetes.io/instance: rhobs
       app.kubernetes.io/name: synthetics-agent
       app.kubernetes.io/part-of: rhobs
-      app.kubernetes.io/version: ${IMAGE_TAG}
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
@@ -195,7 +186,6 @@ objects:
       app.kubernetes.io/instance: rhobs
       app.kubernetes.io/name: synthetics-agent
       app.kubernetes.io/part-of: rhobs
-      app.kubernetes.io/version: ${IMAGE_TAG}
       prometheus: app-sre
   spec:
     selector:
@@ -204,7 +194,6 @@ objects:
         app.kubernetes.io/instance: rhobs
         app.kubernetes.io/name: synthetics-agent
         app.kubernetes.io/part-of: rhobs
-        app.kubernetes.io/version: ${IMAGE_TAG}
     endpoints:
       - port: http-metrics
         path: /metrics


### PR DESCRIPTION
Remove mutable version labels from selectors.

This ensures deployments work correctly across version changes and follows Kubernetes best practices for label selector immutability.