### PR TITLE
Fix URL validation to prevent probe failures

### DIFF
--- a/internal/agent/worker_integration_test.go
+++ b/internal/agent/worker_integration_test.go
@@ -78,7 +78,7 @@ func TestWorker_processProbe_ValidationFailure(t *testing.T) {
 	// Probe with invalid URL
 	probe := api.Probe{
 		ID:        "test-probe-invalid",
-		StaticURL: "https://non-existent-domain-12345.com",
+		StaticURL: "invalid-url-format",
 		Labels: map[string]string{
 			"cluster_id": "cluster-123",
 			"private":    "false",

--- a/internal/agent/worker_test.go
+++ b/internal/agent/worker_test.go
@@ -398,7 +398,7 @@ func TestWorker_processProbe_FallbackLogging(t *testing.T) {
 	// Test with an invalid URL to trigger URL validation failure
 	probe := api.Probe{
 		ID:        "test-probe-invalid",
-		StaticURL: "https://non-existent-domain-12345.com",
+		StaticURL: "invalid-url-format",
 		Labels: map[string]string{
 			"cluster_id": "test-cluster",
 		},

--- a/internal/k8s/probe_edge_cases_test.go
+++ b/internal/k8s/probe_edge_cases_test.go
@@ -39,12 +39,12 @@ func TestProbeManager_ValidateURL_EdgeCases(t *testing.T) {
 		{
 			name:        "HTTP scheme - non-existent domain",
 			url:         "http://non-existent-domain-12345.com",
-			expectError: true, // Will fail because domain doesn't exist
+			expectError: false, // URL format is valid, connectivity is not checked
 		},
 		{
 			name:        "HTTPS scheme - non-existent domain",
 			url:         "https://non-existent-domain-12345.com",
-			expectError: true, // Will fail because domain doesn't exist
+			expectError: false, // URL format is valid, connectivity is not checked
 		},
 	}
 
@@ -63,18 +63,18 @@ func TestProbeManager_ValidateURL_EdgeCases(t *testing.T) {
 func TestProbeManager_ValidateURL_ServerErrors(t *testing.T) {
 	pm := NewProbeManager("test", "")
 
-	// Test server that returns 500
+	// Test server that returns 500 - should not error since we only validate format
 	server500 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server500.Close()
 
 	err := pm.ValidateURL(server500.URL)
-	if err == nil {
-		t.Error("Expected error for 500 status code")
+	if err != nil {
+		t.Errorf("Did not expect error for server responses, only format validation: %v", err)
 	}
 
-	// Test server that returns 404 (should not error)
+	// Test server that returns 404 - should not error since we only validate format
 	server404 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -82,7 +82,7 @@ func TestProbeManager_ValidateURL_ServerErrors(t *testing.T) {
 
 	err = pm.ValidateURL(server404.URL)
 	if err != nil {
-		t.Errorf("Did not expect error for 404 status code: %v", err)
+		t.Errorf("Did not expect error for server responses, only format validation: %v", err)
 	}
 }
 

--- a/internal/k8s/probe_test.go
+++ b/internal/k8s/probe_test.go
@@ -115,7 +115,7 @@ func TestProbeManager_CreateProbeResource_InvalidURL(t *testing.T) {
 
 	probe := api.Probe{
 		ID:        "test-probe-invalid",
-		StaticURL: "https://non-existent-domain-12345.com",
+		StaticURL: "invalid-url-format",
 		Labels: map[string]string{
 			"cluster_id": "cluster-123",
 			"private":    "false",


### PR DESCRIPTION
Fix URL validation to prevent probe failures from transient connectivity issues

The previous URL validation was too strict, performing both format and connectivity validation via HEAD requests. This caused probe processing to fail when target URLs were temporarily unreachable during deployments or due to transient network issues.

Changes:
- Modified ValidateURL to only check format, scheme, and host presence
- Removed connectivity validation (HEAD request) as blackbox exporter handles this
- Updated tests to match new validation behavior
- Probe resources can now be created for temporarily unreachable URLs

This resolves errors like "connection refused" and "EOF" that were preventing valid probe resources from being created during service deployments.