### PR TITLE
SREP-830 - Create ProberManager when running in cluster

### DIFF
--- a/internal/agent/worker.go
+++ b/internal/agent/worker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rhobs/rhobs-synthetics-agent/internal/k8s"
 	"github.com/rhobs/rhobs-synthetics-agent/internal/logger"
 	"github.com/rhobs/rhobs-synthetics-agent/internal/metrics"
+	"github.com/rhobs/rhobs-synthetics-api/pkg/kubeclient"
 )
 
 const defaultProbeNamespace = "default"
@@ -64,7 +65,7 @@ func NewWorker(cfg *Config) (*Worker, error) {
 	probeManager := k8s.NewProbeManager(namespace, kubeConfigPath)
 	var proberManager k8s.ProberManager
 	var err error
-	if kubeConfigPath != "" {
+	if kubeConfigPath != "" || kubeclient.IsRunningInK8sCluster() {
 		proberManager, err = k8s.NewBlackBoxProberManager(namespace, kubeConfigPath, blackboxDeploymentCfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create prober manager: %w", err)

--- a/internal/k8s/prober.go
+++ b/internal/k8s/prober.go
@@ -47,9 +47,6 @@ type BlackBoxProberManager struct {
 
 //func NewBlackBoxProberManager(namespace string, kubeconfigPath string, opts... BlackBoxProberOption) (*BlackBoxProberManager, error) {
 func NewBlackBoxProberManager(namespace string, kubeconfigPath string, cfg BlackboxDeploymentConfig) (*BlackBoxProberManager, error) {
-	if kubeconfigPath == "" {
-		return nil, fmt.Errorf("kubeconfig path must be specified")
-	}
 	client, err := kubeclient.NewClient(kubeclient.Config{KubeconfigPath: kubeconfigPath})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Kubernetes client: %w", err)


### PR DESCRIPTION
Resolves a minor bug where a ProberManager will not be created by a `Worker` if the agent is running as a pod in a cluster. In this scenario, `--kubeconfig` is not explicitly defined, and the agent instead expects to use the default kubeconfig automatically mounted in the pod (which is handled by the `kubeclient.NewClient()` function).