### PR TITLE
Fix RBAC permissions for deployment access

### DIFF
--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -39,6 +39,10 @@ objects:
     - apiGroups: [""]
       resources: ["namespaces"]
       verbs: ["get", "list"]
+    # Access to manage deployments for prober reconciliation
+    - apiGroups: ["apps"]
+      resources: ["deployments"]
+      verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:


### PR DESCRIPTION
Add missing deployment permissions to ClusterRole to resolve RBAC error where synthetics-agent service account cannot get deployments in apps API group during prober reconciliation.