### PR TITLE
Fix RBAC to allow prometheus

### DIFF
--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -27,6 +27,10 @@ objects:
     - apiGroups: ["monitoring.rhobs"]
       resources: ["probes"]
       verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    # Access to Prometheus CRDs (monitoring.rhobs/v1)
+    - apiGroups: ["monitoring.rhobs"]
+      resources: ["prometheuses"]
+      verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
     # Access to Probe CRDs (monitoring.coreos.com/v1) - alternative API group
     - apiGroups: ["monitoring.coreos.com"]
       resources: ["probes"]


### PR DESCRIPTION
This PR fixes the following permission issue:

```
{"time":"2025-09-11T18:44:48.06203978Z","level":"ERROR","msg":"failed to reconcile prometheus instance: failed to retrieve prometheus instance: failed to GET prometheus \"rhobs-int/synthetics-agent\": prometheuses.monitoring.rhobs \"synthetics-agent\" is forbidden: User \"system:serviceaccount:rhobs-int:synthetics-agent\" cannot get resource \"prometheuses\" in API group \"monitoring.rhobs\" in the namespace \"rhobs-int\""}

{"time":"2025-09-11T18:44:48.062053116Z","level":"ERROR","msg":"failed to manage prometheus instance: failed to retrieve prometheus instance: failed to GET prometheus \"rhobs-int/synthetics-agent\": prometheuses.monitoring.rhobs \"synthetics-agent\" is forbidden: User \"system:serviceaccount:rhobs-int:synthetics-agent\" cannot get resource \"prometheuses\" in API group \"monitoring.rhobs\" in the namespace \"rhobs-int\"\n"}
```