### PR TITLE
Agent Namespace Fix

### DIFF
--- a/internal/agent/worker.go
+++ b/internal/agent/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -31,6 +32,14 @@ func NewWorker(cfg *Config) (*Worker, error) {
 	namespace := defaultProbeNamespace
 	kubeConfigPath := ""
 	blackboxDeploymentCfg := k8s.BlackboxDeploymentConfig{}
+
+	// Use NAMESPACE env var (pod's namespace) if available, otherwise use config
+	if envNamespace := os.Getenv("NAMESPACE"); envNamespace != "" {
+		namespace = envNamespace
+	} else if cfg != nil && cfg.Namespace != "" {
+		namespace = cfg.Namespace
+	}
+
 	if cfg != nil {
 		// Create API clients for each configured URL
 		apiURLs := cfg.GetAPIURLs()
@@ -41,9 +50,6 @@ func NewWorker(cfg *Config) (*Worker, error) {
 			}
 		}
 
-		if cfg.Namespace != "" {
-			namespace = cfg.Namespace
-		}
 		if cfg.KubeConfig != "" {
 			kubeConfigPath = cfg.KubeConfig
 		}

--- a/internal/agent/worker.go
+++ b/internal/agent/worker.go
@@ -99,6 +99,9 @@ func NewWorker(cfg *Config) (*Worker, error) {
 	var prometheusManager k8s.PrometheusManager
 	if pm, ok := proberManager.(k8s.PrometheusManager); ok {
 		prometheusManager = pm
+		logger.Info("Prometheus manager initialized successfully")
+	} else {
+		logger.Warn("Prometheus manager not initialized - proberManager does not implement PrometheusManager interface")
 	}
 
 	w := &Worker{
@@ -449,10 +452,11 @@ func (w *Worker) setStatusSelector(ctx context.Context, statusSelector string) (
 
 func (w *Worker) processPrometheus(ctx context.Context, shutdownChan chan struct{}) error {
 	if w.prometheusManager == nil {
+		logger.Debug("skipping prometheus reconciliation - prometheus manager is nil")
 		return nil
 	}
 
-	logger.Debug("reconciling prometheus instance")
+	logger.Info("reconciling prometheus instance")
 	err := w.managePrometheus(ctx)
 	if err != nil {
 		logger.Errorf("failed to reconcile prometheus instance: %v", err)
@@ -477,7 +481,7 @@ func (w *Worker) managePrometheus(ctx context.Context) error {
 		}
 		logger.Info("successfully created prometheus instance for synthetic monitoring")
 	} else {
-		logger.Debug("prometheus instance already exists")
+		logger.Info("prometheus instance already exists")
 	}
 	return nil
 }


### PR DESCRIPTION
Use agent's running namespace from NAMESPACE env var

The agent was configured with namespace 'rhobs' for creating probe resources, but that namespace doesn't exist. The agent runs is configured to run in different namespaces like 'rhobs-int' and has a NAMESPACE environment variable set to its pod namespace.

This change prioritizes the NAMESPACE env var over the config file, ensuring all resources (probes, probers, and Prometheus) are created in the agent's actual running namespace.