### PR TITLE
[SREP-2209] add go.mod and go.sum to auto renovate paths.

### DIFF
--- a/.tekton/renovate.json
+++ b/.tekton/renovate.json
@@ -11,7 +11,9 @@
   ],
   "tekton": {
     "includePaths": [
-      ".tekton/**"
+      ".tekton/**",
+      "go.mod",
+      "go.sum"
     ],
     "enabled": true,
     "packageRules": [


### PR DESCRIPTION
The original change for this ticket isn't having the desired effect. Adding go.mod and go.sum so we can auto approve updates assuming the builds pass. 