### PR TITLE
SREP-4136: Remove empty bearerTokenSecret from Probe CRs

### DIFF
--- a/internal/k8s/probe.go
+++ b/internal/k8s/probe.go
@@ -174,6 +174,13 @@ func (pm *ProbeManager) CreateProbeK8sResource(probe api.Probe, config BlackboxP
 		return fmt.Errorf("failed to convert probe resource to unstructured data: %w", err)
 	}
 
+	// Remove empty bearerTokenSecret -- the Go struct serializes the zero-value
+	// SecretKeySelector as {key:"", name:""} which the prometheus-operator rejects
+	// with "unable to get secret '': resource name may not be empty"
+	if spec, ok := unstructuredCR.Object["spec"].(map[string]interface{}); ok {
+		delete(spec, "bearerTokenSecret")
+	}
+
 	// Define the GVR for Probe resources
 	probeGVR := schema.GroupVersionResource{
 		Group:    pm.probeAPIGroup,


### PR DESCRIPTION
## Problem

Cell-side Probe CRs are rejected by the OBO prometheus-operator with:
```
bearerTokenSecret: unable to get secret "": resource name may not be empty
```

The Go Probe struct serializes the zero-value `SecretKeySelector` as `{key: "", name: ""}`. The OBO operator treats this as an invalid secret reference and rejects the Probe CR, resulting in 0 probe scrape configs on all cell Prometheus instances.

## Fix

Remove the empty `bearerTokenSecret` field from the unstructured object before creating the Probe CR. No bearer token auth is needed for blackbox probing.

## Impact

All cell-side probes (public HCPs) were never being scraped. This fix will enable the Prometheus on each RHOBS cell to scrape the Probe CRs for the first time.

Jira: https://redhat.atlassian.net/browse/SREP-4136