### PR TITLE
Add configurable Prometheus sidecar resource limits

### DIFF
--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -112,6 +112,9 @@ objects:
         remote_write_url: ${PROMETHEUS_REMOTE_WRITE_URL}
         remote_write_tenant: ${PROMETHEUS_REMOTE_WRITE_TENANT}
         api_group: ${PROMETHEUS_API_GROUP}
+        cpu_limits: ${PROMETHEUS_CPU_LIMIT}
+        memory_requests: ${PROMETHEUS_MEMORY_REQUEST}
+        memory_limits: ${PROMETHEUS_MEMORY_LIMIT}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -433,4 +436,19 @@ parameters:
   displayName: OIDC Issuer URL
   description: OIDC issuer URL for token endpoint (optional, only needed for cross-cluster deployments)
   value: ""
+  required: false
+- name: PROMETHEUS_CPU_LIMIT
+  displayName: Prometheus CPU Limit
+  description: Maximum CPU for the Prometheus sidecar that scrapes and remote-writes probe metrics
+  value: "500m"
+  required: false
+- name: PROMETHEUS_MEMORY_REQUEST
+  displayName: Prometheus Memory Request
+  description: Minimum memory for the Prometheus sidecar
+  value: "512Mi"
+  required: false
+- name: PROMETHEUS_MEMORY_LIMIT
+  displayName: Prometheus Memory Limit
+  description: Maximum memory for the Prometheus sidecar. Increase for cells with many probes to prevent OOM during WAL replay.
+  value: "2Gi"
   required: false


### PR DESCRIPTION
## Summary

The Prometheus sidecar that scrapes and remote-writes probe metrics was hardcoded to 1Gi memory. On backplane clusters serving large cells (us-east-1 with 400+ private HCPs), the sidecar OOMs during WAL replay causing CrashLoopBackOff (1666 restarts) and zero private probe metrics being forwarded.

**Root cause**: us-east-1 backplane agents (ue1-1 and ue1-2) have Prometheus sidecars in CrashLoopBackOff with 1Gi memory limit and 1676 WAL segments to replay on startup.

**Fix**: Add template parameters for Prometheus resource configuration so they can be tuned per-target in app-interface:
- `PROMETHEUS_CPU_LIMIT` (default: 500m)
- `PROMETHEUS_MEMORY_REQUEST` (default: 512Mi)
- `PROMETHEUS_MEMORY_LIMIT` (default: 2Gi, up from previous 1Gi)

Large cells can override these in app-interface saas targets:
```yaml
parameters:
  PROMETHEUS_MEMORY_LIMIT: "3Gi"
```

Jira: https://redhat.atlassian.net/browse/RHOBS-1548