### PR TITLE
Add Prometheus resource defaults and config file watching

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/rhobs/rhobs-synthetics-agent/internal/agent"
 	"github.com/rhobs/rhobs-synthetics-agent/internal/logger"
 	"github.com/spf13/cobra"
@@ -28,6 +29,10 @@ func main() {
 				if err := viper.ReadInConfig(); err != nil {
 					return fmt.Errorf("failed to read config: %w", err)
 				}
+				viper.WatchConfig()
+				viper.OnConfigChange(func(e fsnotify.Event) {
+					logger.Infof("Config file changed: %s, reloading", e.Name)
+				})
 			}
 			return nil
 		},

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rhobs/rhobs-synthetics-agent
 go 1.25.0
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/oklog/run v1.2.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.86.1
 	github.com/prometheus/client_golang v1.23.2
@@ -20,7 +21,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.22.1 // indirect
@@ -67,7 +67,7 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/evanphx/json-patch.v5 v5.9.11 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260520065146-aa012df4f4af // indirect

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -37,6 +37,13 @@ type Config struct {
 	Blackbox k8s.BlackboxConfig `mapstructure:"blackbox"`
 }
 
+const (
+	DefaultPrometheusCPURequests    = "100m"
+	DefaultPrometheusCPULimits      = "500m"
+	DefaultPrometheusMemoryRequests = "512Mi"
+	DefaultPrometheusMemoryLimits   = "2Gi"
+)
+
 type PrometheusConfig struct {
 	RemoteWriteURL    string `mapstructure:"remote_write_url"`
 	RemoteWriteTenant string `mapstructure:"remote_write_tenant"`
@@ -46,6 +53,21 @@ type PrometheusConfig struct {
 	MemoryLimits      string `mapstructure:"memory_limits"`
 	ManagedByOperator string `mapstructure:"managed_by_operator"`
 	APIGroup          string `mapstructure:"api_group"`
+}
+
+func (pc *PrometheusConfig) ApplyDefaults() {
+	if pc.CPURequests == "" {
+		pc.CPURequests = DefaultPrometheusCPURequests
+	}
+	if pc.CPULimits == "" {
+		pc.CPULimits = DefaultPrometheusCPULimits
+	}
+	if pc.MemoryRequests == "" {
+		pc.MemoryRequests = DefaultPrometheusMemoryRequests
+	}
+	if pc.MemoryLimits == "" {
+		pc.MemoryLimits = DefaultPrometheusMemoryLimits
+	}
 }
 
 // Validate validates the PrometheusConfig fields

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -577,6 +577,111 @@ func TestPrometheusConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestPrometheusConfig_ApplyDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   PrometheusConfig
+		expected PrometheusConfig
+	}{
+		{
+			name:   "all empty fields get defaults",
+			config: PrometheusConfig{},
+			expected: PrometheusConfig{
+				CPURequests:    DefaultPrometheusCPURequests,
+				CPULimits:      DefaultPrometheusCPULimits,
+				MemoryRequests: DefaultPrometheusMemoryRequests,
+				MemoryLimits:   DefaultPrometheusMemoryLimits,
+			},
+		},
+		{
+			name: "explicit values are preserved",
+			config: PrometheusConfig{
+				CPURequests:    "200m",
+				CPULimits:      "1000m",
+				MemoryRequests: "1Gi",
+				MemoryLimits:   "4Gi",
+			},
+			expected: PrometheusConfig{
+				CPURequests:    "200m",
+				CPULimits:      "1000m",
+				MemoryRequests: "1Gi",
+				MemoryLimits:   "4Gi",
+			},
+		},
+		{
+			name: "partial config fills only missing fields",
+			config: PrometheusConfig{
+				CPULimits:    "750m",
+				MemoryLimits: "3Gi",
+			},
+			expected: PrometheusConfig{
+				CPURequests:    DefaultPrometheusCPURequests,
+				CPULimits:      "750m",
+				MemoryRequests: DefaultPrometheusMemoryRequests,
+				MemoryLimits:   "3Gi",
+			},
+		},
+		{
+			name: "non-resource fields are not touched",
+			config: PrometheusConfig{
+				RemoteWriteURL:    "http://example.com",
+				RemoteWriteTenant: "tenant",
+				ManagedByOperator: "operator",
+				APIGroup:          "monitoring.rhobs",
+			},
+			expected: PrometheusConfig{
+				RemoteWriteURL:    "http://example.com",
+				RemoteWriteTenant: "tenant",
+				ManagedByOperator: "operator",
+				APIGroup:          "monitoring.rhobs",
+				CPURequests:       DefaultPrometheusCPURequests,
+				CPULimits:         DefaultPrometheusCPULimits,
+				MemoryRequests:    DefaultPrometheusMemoryRequests,
+				MemoryLimits:      DefaultPrometheusMemoryLimits,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.config.ApplyDefaults()
+			if tt.config.CPURequests != tt.expected.CPURequests {
+				t.Errorf("CPURequests = %q, want %q", tt.config.CPURequests, tt.expected.CPURequests)
+			}
+			if tt.config.CPULimits != tt.expected.CPULimits {
+				t.Errorf("CPULimits = %q, want %q", tt.config.CPULimits, tt.expected.CPULimits)
+			}
+			if tt.config.MemoryRequests != tt.expected.MemoryRequests {
+				t.Errorf("MemoryRequests = %q, want %q", tt.config.MemoryRequests, tt.expected.MemoryRequests)
+			}
+			if tt.config.MemoryLimits != tt.expected.MemoryLimits {
+				t.Errorf("MemoryLimits = %q, want %q", tt.config.MemoryLimits, tt.expected.MemoryLimits)
+			}
+			if tt.config.RemoteWriteURL != tt.expected.RemoteWriteURL {
+				t.Errorf("RemoteWriteURL = %q, want %q", tt.config.RemoteWriteURL, tt.expected.RemoteWriteURL)
+			}
+			if tt.config.RemoteWriteTenant != tt.expected.RemoteWriteTenant {
+				t.Errorf("RemoteWriteTenant = %q, want %q", tt.config.RemoteWriteTenant, tt.expected.RemoteWriteTenant)
+			}
+		})
+	}
+}
+
+func TestPrometheusConfig_ApplyDefaults_Constants(t *testing.T) {
+	if DefaultPrometheusCPURequests != "100m" {
+		t.Errorf("DefaultPrometheusCPURequests = %q, want '100m'", DefaultPrometheusCPURequests)
+	}
+	if DefaultPrometheusCPULimits != "500m" {
+		t.Errorf("DefaultPrometheusCPULimits = %q, want '500m'", DefaultPrometheusCPULimits)
+	}
+	if DefaultPrometheusMemoryRequests != "512Mi" {
+		t.Errorf("DefaultPrometheusMemoryRequests = %q, want '512Mi'", DefaultPrometheusMemoryRequests)
+	}
+	if DefaultPrometheusMemoryLimits != "2Gi" {
+		t.Errorf("DefaultPrometheusMemoryLimits = %q, want '2Gi'", DefaultPrometheusMemoryLimits)
+	}
+}
+
 func TestLoadConfig_PrometheusConfig(t *testing.T) {
 	// Reset viper to ensure clean state
 	viper.Reset()

--- a/internal/agent/worker.go
+++ b/internal/agent/worker.go
@@ -106,6 +106,7 @@ func NewWorker(cfg *Config) (*Worker, error) {
 
 		// Set Prometheus configuration if config is provided
 		if cfg != nil {
+			cfg.Prometheus.ApplyDefaults()
 			proberManagerConfig.RemoteWriteURL = cfg.Prometheus.RemoteWriteURL
 			proberManagerConfig.RemoteWriteTenant = cfg.Prometheus.RemoteWriteTenant
 			proberManagerConfig.PrometheusResources = k8s.PrometheusResourceConfig{


### PR DESCRIPTION
## Summary

Two fixes for the Prometheus sidecar that scrapes and remote-writes probe metrics:

**1. Resource defaults for empty config values**

When `memory_limits` (or other resource fields) are empty in the config, `parseResourceQuantity("")` returns zero, causing the Prometheus operator to use its own default (1Gi). On backplane clusters serving large cells (us-east-1 with 400+ private HCPs), 1Gi is insufficient, causing OOM and CrashLoopBackOff (1666 restarts on ue1-2).

Now applies sensible defaults when config values are empty:
- CPU: requests=100m, limits=500m
- Memory: requests=512Mi, limits=2Gi

**2. Config file watching**

Enables `viper.WatchConfig()` so changes to the mounted ConfigMap are detected and logged. Currently requires a pod restart to apply the new values (viper reloads internally but the worker uses a startup snapshot). Logs the change event for operator awareness.

Depends on: #199 (template parameters)

Jira: https://redhat.atlassian.net/browse/RHOBS-1548