### PR TITLE
[DRAFT] : fix(probe): add probe_url label and remove last-reconciled from metrics

### DIFF
--- a/internal/k8s/probe.go
+++ b/internal/k8s/probe.go
@@ -252,9 +252,12 @@ func (pm *ProbeManager) CreateProbeResource(probe api.Probe, config BlackboxProb
 		"rhobs.monitoring/managed-by": SyntheticsAgentManagedByValue,
 	}
 
-	// Create target labels starting with basic probe information
+	// Create target labels starting with basic probe information.
+	// probe_url is required so probe_success metrics match the alert rule selector
+	// probe_success{probe_url=~".*api.*"} used by api-ErrorBudgetBurn (ROSAENG-60340).
 	targetLabels := map[string]string{
 		"apiserver_url": probe.StaticURL,
+		"probe_url":     probe.StaticURL,
 	}
 
 	// Add all probe labels to both metadata and target labels generically
@@ -265,7 +268,13 @@ func (pm *ProbeManager) CreateProbeResource(probe api.Probe, config BlackboxProb
 			metadataLabels[metadataKey] = value
 		}
 
-		// Add all labels to target labels as-is
+		// Exclude last-reconciled from metric labels. It changes on every RMO
+		// reconciliation cycle, creating a new Prometheus time series each time.
+		// This breaks burn rate window continuity and for: timer stability in alerts.
+		if key == "last-reconciled" {
+			continue
+		}
+
 		targetLabels[key] = value
 	}
 

--- a/internal/k8s/probe_test.go
+++ b/internal/k8s/probe_test.go
@@ -110,6 +110,18 @@ func TestProbeManager_CreateProbeResource(t *testing.T) {
 	if cr.Spec.Targets.StaticConfig.Labels["cluster_id"] != "cluster-123" {
 		t.Errorf("Expected cluster_id 'cluster-123', got %s", cr.Spec.Targets.StaticConfig.Labels["cluster_id"])
 	}
+
+	// probe_url must be set so probe_success metrics match alert rule selector
+	// probe_success{probe_url=~".*api.*"} used by api-ErrorBudgetBurn (ROSAENG-60340)
+	if cr.Spec.Targets.StaticConfig.Labels["probe_url"] != server.URL {
+		t.Errorf("Expected probe_url '%s', got %s", server.URL, cr.Spec.Targets.StaticConfig.Labels["probe_url"])
+	}
+
+	// last-reconciled must NOT be in target labels — it changes every reconcile cycle,
+	// creating a new Prometheus time series that breaks burn rate window continuity
+	if _, exists := cr.Spec.Targets.StaticConfig.Labels["last-reconciled"]; exists {
+		t.Error("last-reconciled must not be in target labels (it creates time series churn)")
+	}
 }
 
 func TestProbeManager_CreateProbeResource_InvalidURL(t *testing.T) {


### PR DESCRIPTION
Two monitoring bugs confirmed via investigation of [ROSAENG-60340](https://redhat.atlassian.net/browse/ROSAENG-60340):

Bug 1 — agent probe invisible to api-ErrorBudgetBurn alert:  The alert rule uses probe_success{probe_url=~".*api.*"} but the agent probe had no probe_url label, making it completely invisible.   The alert could only see the internal RMO probe (which was healthy), so external NLB/PrivateLink failures never triggered a PD page.

Fix: add probe_url = probe.StaticURL to target labels. The agent  probe URL (https://api.<cluster>...) matches .*api.* so the alert  will now evaluate it correctly.

Bug 2 — last-reconciled label causes time series churn: last-reconciled changes on every RMO reconciliation cycle (driven by HCP condition changes from the OVN bug). Each change creates a new Prometheus time series in RHOBS, breaking burn rate window continuity and resetting the alert for: timer. During an active OVN-triggered reconciliation storm this prevents the alert from ever completing its for: duration.

Fix: exclude last-reconciled from target labels (metric labels). It can still live in k8s object metadata for debugging. Probe data now accumulates stably across reconciliation cycles.

Refs: [ROSAENG-60340](https://redhat.atlassian.net/browse/ROSAENG-60340), OCPBUGS-87020